### PR TITLE
Fixes to include scenery 0.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,15 +97,12 @@
 	
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
-		<kotlin.version>1.1.2-4</kotlin.version>
+		<kotlin.version>1.1.51</kotlin.version>
 		<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
 		<slf4j.version>1.7.25</slf4j.version>
-		<dokka.version>0.9.14</dokka.version>
-		<lwjgl.version>3.1.1</lwjgl.version>
-		<spirvcrossj.version>0.2.6</spirvcrossj.version>
-		<jvrpn.version>1.0.1</jvrpn.version>
+		<lwjgl.version>3.1.3</lwjgl.version>
 		<scijava-common.version>2.64.1-SNAPSHOT</scijava-common.version>
-		<scenery.version>0.1.1-SNAPSHOT</scenery.version>
+		<scenery.version>0.2.0-SNAPSHOT</scenery.version>
 		<javac.target>1.8</javac.target>
 		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<enforcer.skip>true</enforcer.skip>
@@ -122,12 +119,7 @@
 		<dependency>
 			<groupId>net.clearvolume</groupId>
 			<artifactId>cleargl</artifactId>
-			<version>2.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>graphics.scenery</groupId>
-			<artifactId>jopenvr</artifactId>
-			<version>1.0.5</version>
+			<version>2.1.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.coremem</groupId>
@@ -204,12 +196,17 @@
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
-			<version>3.1.2</version>
+			<version>${lwjgl.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>graphics.scenery</groupId>
 			<artifactId>scenery</artifactId>
-			<version>0.1.1-SNAPSHOT</version>
+			<version>${scenery.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
 	</dependencies>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>16.1.0</version>
+		<version>17.1.1</version>
 		<relativePath />
 	</parent>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -85,15 +85,11 @@
 	</ciManagement>	
 	
 	<properties>
-		<scijava.jvm.version>1.8</scijava.jvm.version>
 		<kotlin.version>1.1.51</kotlin.version>
-		<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
 		<slf4j.version>1.7.25</slf4j.version>
 		<lwjgl.version>3.1.3</lwjgl.version>
-		<scijava-common.version>2.64.1-SNAPSHOT</scijava-common.version>
+
 		<scenery.version>0.2.0-SNAPSHOT</scenery.version>
-		<javac.target>1.8</javac.target>
-		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<enforcer.skip>true</enforcer.skip>
 	</properties>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,13 @@
 		<kotlin.version>1.1.51</kotlin.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<lwjgl.version>3.1.3</lwjgl.version>
+		<imagej-mesh.version>0.1.1-SNAPSHOT</imagej-mesh.version>
+		<CoreMem.version>0.4.3</CoreMem.version>
+		<script-editor.version>0.1.5-SNAPSHOT</script-editor.version>
+		<jinput.version>2.0.6</jinput.version>
 
 		<scenery.version>0.2.0-SNAPSHOT</scenery.version>
+		<cleargl.version>2.1.1-SNAPSHOT</cleargl.version>
 		<enforcer.skip>true</enforcer.skip>
 	</properties>
 	
@@ -104,12 +109,12 @@
 		<dependency>
 			<groupId>net.clearvolume</groupId>
 			<artifactId>cleargl</artifactId>
-			<version>2.1.1-SNAPSHOT</version>
+			<version>${cleargl.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.coremem</groupId>
 			<artifactId>CoreMem</artifactId>
-			<version>0.4.3</version>
+			<version>${CoreMem.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
@@ -129,7 +134,6 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
-            <version>0.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
@@ -154,12 +158,11 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>script-editor</artifactId>
-			<version>0.1.5-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.java.jinput</groupId>
 			<artifactId>jinput</artifactId>
-			<version>2.0.6</version>
+			<version>${jinput.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
@@ -176,7 +179,6 @@
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-mesh</artifactId>
-			<version>0.1.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,23 @@
 	</repositories>
 
 	<dependencies>
-
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.jogl</groupId>
+			<artifactId>jogl-all</artifactId>
+			<version>${jogl.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-roi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>net.clearvolume</groupId>
 			<artifactId>cleargl</artifactId>
@@ -195,6 +211,12 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>${slf4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,9 @@
 		<kotlin.version>1.1.51</kotlin.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<lwjgl.version>3.1.3</lwjgl.version>
-		<imagej-mesh.version>0.1.1-SNAPSHOT</imagej-mesh.version>
+		<imagej-mesh.version>0.2.0</imagej-mesh.version>
 		<CoreMem.version>0.4.3</CoreMem.version>
-		<script-editor.version>0.1.5-SNAPSHOT</script-editor.version>
+		<script-editor.version>0.1.5</script-editor.version>
 		<jinput.version>2.0.6</jinput.version>
 
 		<scenery.version>0.2.0-SNAPSHOT</scenery.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
 		<imagej-mesh.version>0.2.0</imagej-mesh.version>
 		<CoreMem.version>0.4.3</CoreMem.version>
 		<script-editor.version>0.1.5</script-editor.version>
-		<jinput.version>2.0.6</jinput.version>
 
 		<scenery.version>0.2.0-SNAPSHOT</scenery.version>
 		<cleargl.version>2.1.1-SNAPSHOT</cleargl.version>
@@ -162,10 +161,6 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>ij</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
 			<artifactId>imagej-ui-swing</artifactId>
 		</dependency>
 		<dependency>
@@ -175,19 +170,6 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>script-editor</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.java.jinput</groupId>
-			<artifactId>jinput</artifactId>
-			<version>${jinput.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>native-lib-loader</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imglib2</groupId>
-			<artifactId>imglib2-ij</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,17 +84,6 @@
 		<url>https://travis-ci.org/scenerygraphics/SciView</url>
 	</ciManagement>	
 	
-	<distributionManagement>
-	  <repository>
-	    <id>imagej.releases</id>
-	    <url>http://maven.imagej.net/content/repositories/releases</url>
-	  </repository>	  
-	  <snapshotRepository>
-	    <id>imagej.snapshots</id>
-	    <url>http://maven.imagej.net/content/repositories/snapshots</url>
-	  </snapshotRepository>
-	</distributionManagement>
-	
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
 		<kotlin.version>1.1.51</kotlin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-stdlib-jre8</artifactId>
-			<version>${kotlin.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
@@ -157,27 +151,11 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>imagej-deprecated</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-ui-swing</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
 			<artifactId>imagej-ops</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>script-editor</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-mesh</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
@@ -189,11 +167,43 @@
 			<artifactId>scenery</artifactId>
 			<version>${scenery.version}</version>
 		</dependency>
+
+		<!-- Runtime scope -->
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jre8</artifactId>
+			<version>${kotlin.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-deprecated</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-ui-swing</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>script-editor</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-mesh</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>${slf4j.version}</version>
+			<scope>runtime</scope>
 		</dependency>
+
+		<!-- Test scope -->
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
 		<version>17.1.1</version>
 		<relativePath />
 	</parent>
-	
+
 	<groupId>sc.iview</groupId>
 	<artifactId>sciview</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	
+
 	<name>SciView</name>
 	<description>This is a 3D visualization package for ImageJ that uses Scenery (graphics.scenery) as a backend.</description>
 	<url>https://github.com/scenerygraphics/SciView</url>
@@ -27,7 +27,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-	
+
 	<developers>
 		<developer>
 			<id>kephale</id>
@@ -61,14 +61,14 @@
 			<properties><id>ctrueden</id></properties>
 		</contributor>
 	</contributors>
-	
+
 	<mailingLists>
 		<mailingList>
 			<name>ImageJ Forum</name>
 			<archive>http://forum.imagej.net/</archive>
 		</mailingList>
 	</mailingLists>
-	
+
 	<scm>
 		<connection>scm:git:git://github.com/scenerygraphics/SciView</connection>
 		<developerConnection>scm:git:git@github.com:scenerygraphics/SciView</developerConnection>
@@ -82,8 +82,8 @@
 	<ciManagement>
 		<system>Travis CI</system>
 		<url>https://travis-ci.org/scenerygraphics/SciView</url>
-	</ciManagement>	
-	
+	</ciManagement>
+
 	<properties>
 		<kotlin.version>1.1.51</kotlin.version>
 		<slf4j.version>1.7.25</slf4j.version>
@@ -97,13 +97,14 @@
 		<cleargl.version>2.1.1-SNAPSHOT</cleargl.version>
 		<enforcer.skip>true</enforcer.skip>
 	</properties>
-	
+
 	<repositories>
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
+
 	<dependencies>
 
 		<dependency>
@@ -196,5 +197,4 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 	</dependencies>
-	
 </project>

--- a/src/main/java/sc/iview/SciView.java
+++ b/src/main/java/sc/iview/SciView.java
@@ -675,10 +675,6 @@ public class SciView extends SceneryBase {
             v.readFromBuffer(image.getName(),byteBuffer,dimensions[0],dimensions[1],dimensions[2],
                     voxelDimensions[0],voxelDimensions[1],voxelDimensions[2],
                     NativeTypeEnum.UnsignedShort,bytesPerVoxel);
-            //v.getColormaps().put("localplasma", "/Users/kharrington/git/scenery/src/main/resources/graphics/scenery/colormap-plasma.tga");
-            v.getColormaps().put("localplasma", "/Users/kharrington/git/scenery/src/main/resources/graphics/scenery/volumes/colormap-plasma.png");
-            v.setColormap("localplasma");
-            //v.setColormap("plasma");
 
             System.out.println( v.getColormaps() );
 


### PR DESCRIPTION
This updates scenery to 0.2.0-SNAPSHOT and fixes some issues, e.g. a hardcoded colormap path.