### PR TITLE
General volume mesh overlay fix

### DIFF
--- a/src/main/java/sc/iview/SciView.java
+++ b/src/main/java/sc/iview/SciView.java
@@ -868,6 +868,13 @@ public class SciView extends SceneryBase {
                           voxelDimensions[1], voxelDimensions[2], nType, bytesPerVoxel );
 
         getScene().addChild( v );
+        GLVector scaleVec = new GLVector(0.5f*(float) dimensions[0], 0.5f*(float) dimensions[1], 0.5f*(float) dimensions[2] );
+
+        v.setScale( scaleVec );
+
+        // TODO: This translation should probably be accounted for in scenery; volumes use a corner-origin and
+        //        meshes use center-origin coordinate systems.
+        v.setPosition( v.getPosition().plus( new GLVector( 0.5f*dimensions[0]-0.5f, 0.5f*dimensions[1]-0.5f, 0.5f*dimensions[2]-0.5f) ) );
 
         v.setTrangemin( minVal );
         v.setTrangemax( maxVal );

--- a/src/main/java/sc/iview/commands/demo/VolumeRenderDemo.java
+++ b/src/main/java/sc/iview/commands/demo/VolumeRenderDemo.java
@@ -86,7 +86,9 @@ public class VolumeRenderDemo implements Command {
     public void run() {
         final Dataset cube;
         try {
-            File cubeFile = ResourceLoader.createFile( getClass(), "/cored_cube_var2_8bit.tif" );
+            //File cubeFile = ResourceLoader.createFile( getClass(), "/cored_cube_var2_8bit.tif" );
+
+            File cubeFile = ResourceLoader.createFile( getClass(), "/161122_angle001_t0188_segmentation_8bit_cube.tif" );
             cube = datasetIO.open( cubeFile.getAbsolutePath() );
         }
         catch (IOException exc) {
@@ -97,29 +99,18 @@ public class VolumeRenderDemo implements Command {
         System.out.println( cube.firstElement().getClass() );
         Node v = sciView.addVolume( cube, new float[] { 1, 1, 1 } );
 
-        float rescale = 0.5f;
-
-        GLVector scaleVec = new GLVector(rescale * (float) cube.getWidth(), rescale * (float) cube.getHeight(), rescale * (float) cube.getDepth());
-
-        Node.OrientedBoundingBox volBB = v.generateBoundingBox();
-
-        v.setScale( scaleVec );
-
         if (iso) {
             int isoLevel = 1;
 
             @SuppressWarnings("unchecked")
             Img<UnsignedByteType> cubeImg = ( Img<UnsignedByteType> ) cube.getImgPlus().getImg();
 
-            Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().apply( cubeImg, new UnsignedByteType( isoLevel ) );
+            //Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().apply( cubeImg, new UnsignedByteType( isoLevel ) );
+            Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().maxEntropy( cubeImg );
 
             Mesh m = ops.geom().marchingCubes( bitImg, isoLevel, new BitTypeVertexInterpolator() );
 
-            Node scMesh = sciView.addMesh( m );
-
-            Node.OrientedBoundingBox meshBB = scMesh.generateBoundingBox();
-
-            scMesh.setPosition( new GLVector( -0.5f*cube.getWidth()+0.5f, -0.5f*cube.getHeight()+0.5f, -0.5f*cube.getDepth()+0.5f ) );
+            sciView.addMesh( m );
         }
 
     }

--- a/src/main/java/sc/iview/commands/demo/VolumeRenderDemo.java
+++ b/src/main/java/sc/iview/commands/demo/VolumeRenderDemo.java
@@ -86,9 +86,8 @@ public class VolumeRenderDemo implements Command {
     public void run() {
         final Dataset cube;
         try {
-            //File cubeFile = ResourceLoader.createFile( getClass(), "/cored_cube_var2_8bit.tif" );
+            File cubeFile = ResourceLoader.createFile( getClass(), "/cored_cube_var2_8bit.tif" );
 
-            File cubeFile = ResourceLoader.createFile( getClass(), "/161122_angle001_t0188_segmentation_8bit_cube.tif" );
             cube = datasetIO.open( cubeFile.getAbsolutePath() );
         }
         catch (IOException exc) {
@@ -105,8 +104,8 @@ public class VolumeRenderDemo implements Command {
             @SuppressWarnings("unchecked")
             Img<UnsignedByteType> cubeImg = ( Img<UnsignedByteType> ) cube.getImgPlus().getImg();
 
-            //Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().apply( cubeImg, new UnsignedByteType( isoLevel ) );
-            Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().maxEntropy( cubeImg );
+            Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().apply( cubeImg, new UnsignedByteType( isoLevel ) );
+            //Img<BitType> bitImg = ( Img<BitType> ) ops.threshold().maxEntropy( cubeImg );
 
             Mesh m = ops.geom().marchingCubes( bitImg, isoLevel, new BitTypeVertexInterpolator() );
 


### PR DESCRIPTION
This works for images that are uniform over all dimensions. There is an upstream bug that leads to an off-by-one error in 3D texture allocation (see JOGL GLBuffers image size allocations). The plan is to account for this in ClearGL.