### PR TITLE
Publish to event service on floor toggle

### DIFF
--- a/src/main/java/sc/iview/commands/edit/ToggleFloor.java
+++ b/src/main/java/sc/iview/commands/edit/ToggleFloor.java
@@ -28,12 +28,15 @@
  */
 package sc.iview.commands.edit;
 
+import com.sun.org.glassfish.gmbal.ParameterNames;
 import org.scijava.command.Command;
+import org.scijava.event.EventService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Menu;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import sc.iview.SciView;
+import sc.iview.event.NodeChangedEvent;
 
 import static sc.iview.commands.MenuWeights.EDIT;
 import static sc.iview.commands.MenuWeights.EDIT_TOGGLE_FLOOR;
@@ -49,9 +52,13 @@ public class ToggleFloor implements Command {
     @Parameter
     private SciView sciView;
 
+    @Parameter
+    private EventService eventService;
+
     @Override
     public void run() {
         sciView.getFloor().setVisible( !sciView.getFloor().getVisible() );
+        eventService.publish(new NodeChangedEvent(sciView.getFloor()));
     }
 
 }


### PR DESCRIPTION
Clicking the Floor Toggle command on the menu was not publishing to the event service. This has been corrected. Addresses #163