### PR TITLE
Added a menu-item to choose current renderer

### DIFF
--- a/src/main/java/sc/iview/SciView.java
+++ b/src/main/java/sc/iview/SciView.java
@@ -85,6 +85,7 @@ import org.scijava.log.LogService;
 import org.scijava.menu.MenuService;
 import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
+import org.scijava.prefs.PrefService;
 import org.scijava.service.SciJavaService;
 import org.scijava.thread.ThreadService;
 import org.scijava.ui.behaviour.ClickBehaviour;
@@ -93,6 +94,7 @@ import org.scijava.ui.swing.menu.SwingJMenuBarCreator;
 import org.scijava.util.ColorRGB;
 import org.scijava.util.Colors;
 import org.scijava.util.VersionUtils;
+import sc.iview.commands.edit.RenderingDeviceChooser;
 import sc.iview.commands.view.NodePropertyEditor;
 import sc.iview.controls.behaviours.CameraTranslateControl;
 import sc.iview.controls.behaviours.NodeTranslateControl;
@@ -2163,6 +2165,10 @@ public class SciView extends SceneryBase implements CalibratedRealInterval<Calib
 
         System.setProperty( "scijava.log.level:sc.iview", "debug" );
         Context context = new Context( ImageJService.class, SciJavaService.class, SCIFIOService.class, ThreadService.class);
+
+        //setup the System properties just in case the sciview shall be created anew
+        RenderingDeviceChooser.setupSystemProperties(
+                context.service(PrefService.class).get(RenderingDeviceChooser.class,"selectedRenderer") );
 
         SciViewService sciViewService = context.service( SciViewService.class );
         SciView sciView = sciViewService.getOrCreateActiveSciView();

--- a/src/main/java/sc/iview/commands/LaunchViewer.java
+++ b/src/main/java/sc/iview/commands/LaunchViewer.java
@@ -33,11 +33,13 @@ import org.scijava.command.Command;
 import org.scijava.display.DisplayService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.prefs.PrefService;
 import org.scijava.ui.UIService;
 
 import sc.iview.SciView;
 import sc.iview.SciViewService;
 import sc.iview.display.SciViewDisplay;
+import sc.iview.commands.edit.RenderingDeviceChooser;
 
 /**
  * Created by kharrington on 6/20/17.
@@ -54,11 +56,18 @@ public class LaunchViewer implements Command {
     @Parameter(required = false)
     private UIService uiService;
 
+    @Parameter
+    private PrefService prefsService;
+
     @Parameter(type = ItemIO.OUTPUT)
     private SciView sciView = null;
 
     @Override
     public void run() {
+        //setup the System properties just in case the sciview shall be created anew
+        RenderingDeviceChooser.setupSystemProperties(
+                prefsService.get(RenderingDeviceChooser.class,"selectedRenderer") );
+
         final SciViewDisplay display = displayService.getActiveDisplay(SciViewDisplay.class);
         if (display == null)
             sciView = sciViewService.getOrCreateActiveSciView();

--- a/src/main/java/sc/iview/commands/MenuWeights.java
+++ b/src/main/java/sc/iview/commands/MenuWeights.java
@@ -58,6 +58,7 @@ public final class MenuWeights {
     public static final double EDIT_TOGGLE_FLOOR = 50;
     public static final double EDIT_DELETE_OBJECT = 100;
     public static final double EDIT_SCIVIEW_SETTINGS = 200;
+    public static final double EDIT_CHOOSE_RENDERER = 201;
 
     public static final double PROCESS_ISOSURFACE = 0;
     public static final double PROCESS_CONVEX_HULL = 1;

--- a/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
+++ b/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
@@ -94,6 +94,8 @@ public class RenderingDeviceChooser extends DynamicCommand {
             logService.info("Only one renderer device is available, using it.");
         }
         else {
+            if (selectedRenderer.startsWith("SciView")) return;
+            //else
             //ask sciView to actually switch to the selected renderer
             logService.info("Switching to device: "+selectedRenderer);
             if (selectedRenderer.startsWith("OpenGL")) {
@@ -106,12 +108,45 @@ public class RenderingDeviceChooser extends DynamicCommand {
     }
 
 
+    /** Setup system properties scenery.Renderer and scenery.Renderer.Device based
+     *  on the provided parameter, if none of them is set or user has not selected
+     *  a particular renderer. The input parameter is expected to be one of the
+     *  possible menu items that the listAvailRenderers() can generate. */
+    static public void setupSystemProperties(final String selectedRenderer) {
+        //do nothing if "nothing" is requested...
+        if (selectedRenderer == null) return;
+
+        //do nothing if properties are already setup -- do not change them
+        if (System.getProperty("scenery.Renderer") != null
+         || System.getProperty("scenery.Renderer.Device") != null) return;
+
+        System.out.println("Considering the last selected renderer: "+selectedRenderer);
+
+        //both system properties are not set if we got here,
+        //do nothing if "automagic" is requested
+        if (selectedRenderer.startsWith("SciView")) return;
+
+        if (selectedRenderer.startsWith("OpenGL")) {
+            System.setProperty("scenery.Renderer", "OpenGLRenderer");
+            //
+            System.out.println("Setting up system property: scenery.Renderer=OpenGLRenderer");
+        } else {
+            System.setProperty("scenery.Renderer","VulkanRenderer");
+            System.setProperty("scenery.Renderer.Device", selectedRenderer.substring(8));
+            //
+            System.out.println("Setting up system property: scenery.Renderer=VulkanRenderer");
+            System.out.println("Setting up system property: scenery.Renderer.Device="+selectedRenderer.substring(8));
+        }
+    }
+
     /** Discover renderers and compile a list with their names. */
     static public List<String> listAvailRenderers(final SciView sciView) {
         final Renderer r = sciView.getSceneryRenderer();
         System.out.println("The current renderer: "+r.toString());
 
         final List<String> availRenderers = new ArrayList<>(5);
+        availRenderers.add("SciView decides itself at start up");
+
         if (r instanceof OpenGLRenderer) {
             availRenderers.add("OpenGL: default renderer");
             final String preferredDev = System.getProperty("scenery.Renderer.Device");

--- a/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
+++ b/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
@@ -28,7 +28,6 @@
  */
 package sc.iview.commands.edit;
 
-import graphics.scenery.SceneryElement;
 import graphics.scenery.backends.Renderer;
 import graphics.scenery.backends.opengl.OpenGLRenderer;
 import graphics.scenery.backends.vulkan.VulkanRenderer;
@@ -46,11 +45,12 @@ import java.util.List;
 @Plugin(type = Command.class, name = "DeviceChooserDialog")
 public class RenderingDeviceChooser extends DynamicCommand {
 
-    //dialog will not show if UI is not available
+    //since dialog will not show if UI is not available,
+    //we need UIService to have someone to ask to show the UI
     @Parameter
     private UIService uiService;
 
-    //some "console-style" reporting
+    //for reporting
     @Parameter
     private LogService logService;
 
@@ -67,8 +67,7 @@ public class RenderingDeviceChooser extends DynamicCommand {
 
     void fillAvailRenderers() {
         availRenderers = listAvailRenderers(sciView);
-        if (availRenderers.size() > 1)
-        {
+        if (availRenderers.size() > 1) {
             logService.info("Will be choosing from these devices:");
             for (String d : availRenderers) logService.info("  "+d);
 
@@ -89,7 +88,7 @@ public class RenderingDeviceChooser extends DynamicCommand {
             throw new RuntimeException("SciView must be running!");
 
         if (availRenderers.size() == 0) {
-            logService.warn("No renderer device available!");
+            logService.warn("No renderer device available! Doing nothing.");
         }
         else if (availRenderers.size() == 1) {
             logService.info("Only one renderer device is available, using it.");
@@ -107,10 +106,10 @@ public class RenderingDeviceChooser extends DynamicCommand {
     }
 
 
-    // discover renderers and compile a list with their names
+    /** Discover renderers and compile a list with their names. */
     static public List<String> listAvailRenderers(final SciView sciView) {
         final Renderer r = sciView.getSceneryRenderer();
-        System.out.println( "The current renderer: "+r.toString() );
+        System.out.println("The current renderer: "+r.toString());
 
         final List<String> availRenderers = new ArrayList<>(5);
         if (r instanceof OpenGLRenderer) {

--- a/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
+++ b/src/main/java/sc/iview/commands/edit/RenderingDeviceChooser.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * Scenery-backed 3D visualization package for ImageJ.
+ * %%
+ * Copyright (C) 2016 - 2018 SciView developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.iview.commands.edit;
+
+import graphics.scenery.SceneryElement;
+import graphics.scenery.backends.Renderer;
+import graphics.scenery.backends.opengl.OpenGLRenderer;
+import graphics.scenery.backends.vulkan.VulkanRenderer;
+import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+import sc.iview.SciView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Plugin(type = Command.class, name = "DeviceChooserDialog")
+public class RenderingDeviceChooser extends DynamicCommand {
+
+    //dialog will not show if UI is not available
+    @Parameter
+    private UIService uiService;
+
+    //some "console-style" reporting
+    @Parameter
+    private LogService logService;
+
+    //the main actor!
+    @Parameter
+    private SciView sciView;
+
+
+    @Parameter(label = "Select renderer:",
+               initializer = "fillAvailRenderers", choices = {})
+    private String selectedRenderer = "no renderer";
+
+    List<String> availRenderers = new ArrayList<>(5);
+
+    void fillAvailRenderers() {
+        availRenderers = listAvailRenderers(sciView);
+        if (availRenderers.size() > 1)
+        {
+            logService.info("Will be choosing from these devices:");
+            for (String d : availRenderers) logService.info("  "+d);
+
+            //we need the GUI to be visible, otherwise the ImageJ dialogs do not show!
+            if (!uiService.isVisible()) uiService.showUI();
+
+            //setup the combo list with the devices
+            this.getInfo()
+                .getMutableInput("selectedRenderer", String.class)
+                .setChoices( availRenderers );
+        }
+    }
+
+
+    @Override
+    public void run() {
+        if (sciView == null)
+            throw new RuntimeException("SciView must be running!");
+
+        if (availRenderers.size() == 0) {
+            logService.warn("No renderer device available!");
+        }
+        else if (availRenderers.size() == 1) {
+            logService.info("Only one renderer device is available, using it.");
+        }
+        else {
+            //ask sciView to actually switch to the selected renderer
+            logService.info("Switching to device: "+selectedRenderer);
+            if (selectedRenderer.startsWith("OpenGL")) {
+                sciView.replaceRenderer("OpenGLRenderer",true);
+            } else {
+                System.setProperty("scenery.Renderer.Device", selectedRenderer.substring(8));
+                sciView.replaceRenderer("VulkanRenderer",true);
+            }
+        }
+    }
+
+
+    // discover renderers and compile a list with their names
+    static public List<String> listAvailRenderers(final SciView sciView) {
+        final Renderer r = sciView.getSceneryRenderer();
+        System.out.println( "The current renderer: "+r.toString() );
+
+        final List<String> availRenderers = new ArrayList<>(5);
+        if (r instanceof OpenGLRenderer) {
+            availRenderers.add("OpenGL: default renderer");
+            final String preferredDev = System.getProperty("scenery.Renderer.Device");
+            if (preferredDev == null) {
+                availRenderers.add("Vulkan: first available renderer");
+            } else {
+                availRenderers.add("Vulkan: " + preferredDev);
+            }
+        } else if (r instanceof VulkanRenderer) {
+            availRenderers.addAll( ((VulkanRenderer)r).getDiscoveredDevices() );
+            availRenderers.add("OpenGL: default renderer");
+        } else
+            System.out.println("Unrecognized renderer!");
+
+        return availRenderers;
+    }
+}

--- a/src/main/java/sc/iview/commands/edit/RenderingDeviceChooserMenuItem.java
+++ b/src/main/java/sc/iview/commands/edit/RenderingDeviceChooserMenuItem.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * Scenery-backed 3D visualization package for ImageJ.
+ * %%
+ * Copyright (C) 2016 - 2018 SciView developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.iview.commands.edit;
+
+import org.scijava.command.*;
+import org.scijava.plugin.Menu;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import sc.iview.SciView;
+
+import static sc.iview.commands.MenuWeights.*;
+
+@Plugin(type = Command.class, menuRoot = "SciView", //
+menu = {@Menu(label = "Edit", weight = EDIT), //
+        @Menu(label = "Choose Renderer", weight = EDIT_CHOOSE_RENDERER)})
+public class RenderingDeviceChooserMenuItem implements Command {
+
+    @Parameter
+    private SciView sciView;
+
+    @Parameter
+    private CommandService cmdService;
+
+    @Override
+    public void run() {
+        cmdService.run(RenderingDeviceChooser.class,true,"sciView",sciView);
+    }
+}


### PR DESCRIPTION
I propose to add an Edit -> Choose Renderer menu item that triggers a pure Fiji plugin (so that necessary GUI params harvesting can take place). The Fiji plugin needs to get `SciView` service injected and than it works on its own. Specifically:

- when started, it considers given SciView context (actually, the current `scenery.Renderer`) and populates the choice box with available options
- avail options when OpenGL backend is the current one are:
  - OpenGL to force the scenery to restart this backend
  - if `scenery.Renderer.Device` is available, the second menu item contains it,
  - else the second menu item says "Vulkan: first available renderer"

- avail options when Vulkan backend is the current one are:
  - list of discovered vulkan devices, one by one, allowing user to switch among available vulkan devices (which is what Vlado needs now)
  - OpenGL to switch back to OpenGL backend

Essentially the idea is that user touches this menu item only when she is not satisfied with the choice of renderer that scenery has made. If you end up in OpenGL, you can switch to Vulkan. If after that your not happy with the currently chosen Vulkan, you can alter it. And vice versa.

Since the choice is a standard scijava plugin, the last choice is memorized (which becomes useful if switching again from OpenGL back to vulkan, it can go to the last chosen vulkan device directly).