### PR TITLE
PropertyEditor enhancements

### DIFF
--- a/src/main/java/sc/iview/ui/SwingGroupingInputHarvester.kt
+++ b/src/main/java/sc/iview/ui/SwingGroupingInputHarvester.kt
@@ -60,7 +60,7 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
                  * @param e the event to be processed
                  */
                 override fun mouseClicked(e: MouseEvent?) {
-                    if(e?.clickCount == 2) {
+                    if(e?.clickCount == 1) {
                         panel.component.isVisible = !panel.component.isVisible
 
                         if(panel.component.isVisible) {

--- a/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -65,10 +65,20 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
-import javax.swing.*
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JMenuItem
+import javax.swing.JPanel
+import javax.swing.JPopupMenu
+import javax.swing.JScrollPane
+import javax.swing.JSplitPane
+import javax.swing.JTextArea
+import javax.swing.JTree
+import javax.swing.WindowConstants
 import javax.swing.event.TreeSelectionEvent
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.TreeNode
 import javax.swing.tree.TreePath
 import javax.swing.tree.TreeSelectionModel
 
@@ -144,12 +154,14 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
         if (node != sciView.activeNode) {
             updateProperties(sciView.activeNode)
         }
+        updateTree(node)
     }
 
     @EventHandler
     private fun onEvent(evt: NodeActivatedEvent) {
         val node = evt.node ?: return
         updateProperties(node)
+        updateTree(node)
     }
 
     /** Initializes [.panel].  */
@@ -238,6 +250,21 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 }
             }
         })
+    }
+
+    private fun updateTree(node: Node) {
+        val treeNode = getTreeNode(node, treeModel.root as TreeNode)?: return
+        treeModel.nodeChanged(treeNode)
+    }
+
+    private fun getTreeNode(node: Node, parent: TreeNode): TreeNode? {
+        for(i in 0..treeModel.getChildCount(parent)-1) {
+            val child = treeModel.getChild(parent, i) as SwingSceneryTreeNode
+            if(child.node == node) return child
+            val treeNode = getTreeNode(node, child)
+            if(treeNode != null) return treeNode
+        }
+        return null;
     }
 
     var currentNode: Node? = null

--- a/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -285,6 +285,7 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 val pluginInstance = pluginService.createInstance(pluginInfo)
                 val harvester = pluginInstance as SwingGroupingInputHarvester
                 inputPanel = harvester.createInputPanel()
+                inputPanel.component.layout = MigLayout("fillx,wrap 1", "[right,fill,grow]")
 
                 // Build the panel.
                 try {

--- a/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/java/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -151,7 +151,7 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
     @EventHandler
     private fun onEvent(evt: NodeChangedEvent) {
         val node = evt.node ?: return
-        if (node != sciView.activeNode) {
+        if (node == sciView.activeNode) {
             updateProperties(sciView.activeNode)
         }
         updateTree(node)


### PR DESCRIPTION
- Open and close input harvester groups via single click (this is the expected behaviour for a group label with an arrow)
- Remove empty space on the right of the `SwingNodePropertyEditor`:
![image](https://user-images.githubusercontent.com/708121/103687748-1371a800-4f91-11eb-8d70-acbaca83c4af.png)
- update tree on node change