### PR TITLE
SciView: improve add methods

### DIFF
--- a/src/main/java/sc/iview/SciView.kt
+++ b/src/main/java/sc/iview/SciView.kt
@@ -576,7 +576,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      */
     @JvmOverloads
     fun addBox(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), size: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR,
-               inside: Boolean = false): Box {
+               inside: Boolean = false, block: Box.() -> Unit = {}): Box {
         // TODO: use a material from the current palate by default
         val boxmaterial = Material()
         boxmaterial.ambient = Vector3f(1.0f, 0.0f, 0.0f)
@@ -586,7 +586,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         val box = Box(size, inside)
         box.material = boxmaterial
         box.position = position
-        return addNode(box)
+        return addNode(box, block = block)
     }
 
     /**
@@ -594,7 +594,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return the Node corresponding to the sphere
      */
     @JvmOverloads
-    fun addSphere(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), radius: Float = 1f, color: ColorRGB = DEFAULT_COLOR): Sphere {
+    fun addSphere(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), radius: Float = 1f, color: ColorRGB = DEFAULT_COLOR, block: Sphere.() -> Unit = {}): Sphere {
         val material = Material()
         material.ambient = Vector3f(1.0f, 0.0f, 0.0f)
         material.diffuse = Utils.convertToVector3f(color)
@@ -603,8 +603,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         val sphere = Sphere(radius, 20)
         sphere.material = material
         sphere.position = position
-
-        return addNode(sphere)
+        return addNode(sphere, block = block)
     }
 
     /**
@@ -615,10 +614,10 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param num_segments number of segments to represent the cylinder
      * @return  the Node corresponding to the cylinder
      */
-    fun addCylinder(position: Vector3f, radius: Float, height: Float, num_segments: Int): Cylinder {
+    fun addCylinder(position: Vector3f, radius: Float, height: Float, num_segments: Int, block: Cylinder.() -> Unit = {}): Cylinder {
         val cyl = Cylinder(radius, height, num_segments)
         cyl.position = position
-        return addNode(cyl)
+        return addNode(cyl, block = block)
     }
 
     /**
@@ -629,10 +628,10 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param num_segments number of segments used to represent cone
      * @return  the Node corresponding to the cone
      */
-    fun addCone(position: Vector3f, radius: Float, height: Float, num_segments: Int): Cone {
+    fun addCone(position: Vector3f, radius: Float, height: Float, num_segments: Int, block: Cone.() -> Unit = {}): Cone {
         val cone = Cone(radius, height, num_segments, Vector3f(0.0f, 0.0f, 1.0f))
         cone.position = position
-        return addNode(cone)
+        return addNode(cone, block = block)
     }
 
     /**
@@ -643,8 +642,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return the Node corresponding to the line
      */
     @JvmOverloads
-    fun addLine(start: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), stop: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR): Line {
-        return addLine(arrayOf(start, stop), color, 0.1)
+    fun addLine(start: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), stop: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR, block: Line.() -> Unit = {}): Line {
+        return addLine(arrayOf(start, stop), color, 0.1, block)
     }
 
     /**
@@ -654,7 +653,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param edgeWidth width of line segments
      * @return the Node corresponding to the line
      */
-    fun addLine(points: Array<Vector3f>, color: ColorRGB, edgeWidth: Double): Line {
+    @JvmOverloads
+    fun addLine(points: Array<Vector3f>, color: ColorRGB, edgeWidth: Double, block: Line.() -> Unit = {}): Line {
         val material = Material()
         material.ambient = Vector3f(1.0f, 1.0f, 1.0f)
         material.diffuse = Utils.convertToVector3f(color)
@@ -666,14 +666,15 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         line.edgeWidth = edgeWidth.toFloat()
         line.material = material
         line.position = points[0]
-        return addNode(line)
+        return addNode(line, block = block)
     }
 
     /**
      * Add a PointLight source at the origin
      * @return a Node corresponding to the PointLight
      */
-    fun addPointLight(): PointLight {
+    @JvmOverloads
+    fun addPointLight(block: PointLight.() -> Unit = {}): PointLight {
         val material = Material()
         material.ambient = Vector3f(1.0f, 0.0f, 0.0f)
         material.diffuse = Vector3f(0.0f, 1.0f, 0.0f)
@@ -682,7 +683,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         light.material = material
         light.position = Vector3f(0.0f, 0.0f, 0.0f)
         lights!!.add(light)
-        return addNode(light)
+        return addNode(light, block = block)
     }
 
     /**
@@ -762,7 +763,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     @JvmOverloads
     fun addPointCloud(points: Collection<RealLocalizable>,
                       name: String? = "PointCloud",
-                      pointSize : Float = 1.0f): PointCloud {
+                      pointSize : Float = 1.0f,
+                      block: PointCloud.() -> Unit = {}): PointCloud {
         val flatVerts = FloatArray(points.size * 3)
         var k = 0
         for (point in points) {
@@ -782,7 +784,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         pointCloud.position = Vector3f(0f, 0f, 0f)
 
         pointCloud.setupPointCloud()
-        return addNode(pointCloud)
+        return addNode(pointCloud, block = block)
     }
 
     /**
@@ -790,10 +792,11 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param pointCloud existing PointCloud to add to scene
      * @return a Node corresponding to the PointCloud
      */
-    fun addPointCloud(pointCloud: PointCloud): PointCloud {
+    @JvmOverloads
+    fun addPointCloud(pointCloud: PointCloud, block: PointCloud.() -> Unit = {}): PointCloud {
         pointCloud.setupPointCloud()
         pointCloud.position = Vector3f(0f, 0f, 0f)
-        return addNode(pointCloud)
+        return addNode(pointCloud, block = block)
     }
 
     /**
@@ -803,8 +806,9 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return a Node corresponding to the Node
      */
     @JvmOverloads
-    fun <N: Node?> addNode(n: N, activePublish: Boolean = true): N {
+    fun <N: Node?> addNode(n: N, activePublish: Boolean = true, block: N.() -> Unit = {}): N {
         n?.let {
+            it.block()
             scene.addChild(it)
             objectService.addObject(n)
             if (blockOnNewNodes) {
@@ -1123,14 +1127,15 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param image image to add as a volume
      * @return a Node corresponding to the Volume
      */
-    fun addVolume(image: Dataset): Volume {
+    @JvmOverloads
+    fun addVolume(image: Dataset, block: Volume.() -> Unit = {}): Volume {
         val voxelDims = FloatArray(image.numDimensions())
         for (d in voxelDims.indices) {
             val inValue = image.axis(d).averageScale(0.0, 1.0)
             if (image.axis(d).unit() == null) voxelDims[d] = inValue.toFloat() else voxelDims[d] = unitService.value(inValue, image.axis(d).unit(), axis(d)!!.unit()).toFloat()
         }
         logger.info("Adding with ${voxelDims.joinToString(",")}")
-        return addVolume(image, voxelDims)
+        return addVolume(image, voxelDims, block)
     }
 
     /**
@@ -1139,10 +1144,11 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param voxelDimensions dimensions of voxels in volume
      * @return a Node corresponding to the Volume
      */
+    @JvmOverloads
     @Suppress("UNCHECKED_CAST")
-    fun addVolume(image: Dataset, voxelDimensions: FloatArray): Volume {
+    fun addVolume(image: Dataset, voxelDimensions: FloatArray, block: Volume.() -> Unit = {}): Volume {
         return addVolume<RealType<*>>(image.imgPlus as RandomAccessibleInterval<RealType<*>>, image.name ?: "Volume",
-                *voxelDimensions)
+                *voxelDimensions, block = block)
     }
 
     /**
@@ -1151,8 +1157,9 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the volume
     </T> */
-    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume"): Volume {
-        return addVolume(image, name, 1f, 1f, 1f)
+    @JvmOverloads
+    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume", block: Volume.() -> Unit = {}): Volume {
+        return addVolume(image, name, 1f, 1f, 1f, block = block)
     }
 
     /**
@@ -1161,8 +1168,9 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the volume
     </T> */
-    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray): Volume {
-        return addVolume(image, "volume", *voxelDimensions)
+    @JvmOverloads
+    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray, block: Volume.() -> Unit = {}): Volume {
+        return addVolume(image, "volume", *voxelDimensions, block = block)
     }
 
     /**
@@ -1251,13 +1259,15 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> Type of the dataset.
      * @return THe node corresponding to the volume just added.
     </T> */
+    @JvmOverloads
     fun <T : RealType<T>> addVolume(sac: SourceAndConverter<T>,
                                     numTimepoints: Int,
                                     name: String = "Volume",
-                                    vararg voxelDimensions: Float): Volume {
+                                    vararg voxelDimensions: Float,
+                                    block: Volume.() -> Unit = {}): Volume {
         val sources: MutableList<SourceAndConverter<T>> = ArrayList()
         sources.add(sac)
-        return addVolume(sources, numTimepoints, name, *voxelDimensions)
+        return addVolume(sources, numTimepoints, name, *voxelDimensions, block = block)
     }
 
     /**
@@ -1269,8 +1279,10 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the Volume
     </T> */
+    @JvmName("addVolume1")
+    @JvmOverloads
     fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume",
-                                    vararg voxelDimensions: Float): Volume {
+                                    vararg voxelDimensions: Float, block: Volume.() -> Unit = {}): Volume {
         //log.debug( "Add Volume " + name + " image: " + image );
         val dimensions = LongArray(image.numDimensions())
         image.dimensions(dimensions)
@@ -1299,7 +1311,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
             converterSetups.add(BigDataViewer.createConverterSetup(source, setupId.getAndIncrement()))
             sources.add(source)
         }
-        val v = addVolume(sources, numTimepoints, name, *voxelDimensions)
+        val v = addVolume(sources, numTimepoints, name, *voxelDimensions, block = block)
         v.metadata.set("RandomAccessibleInterval", image)
         return v
     }
@@ -1315,12 +1327,14 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> Type of the dataset.
      * @return THe node corresponding to the volume just added.
     </T> */
+    @JvmOverloads
     @Suppress("UNCHECKED_CAST")
     fun <T : NumericType<T>> addVolume(sources: List<SourceAndConverter<T>>,
                                        converterSetups: ArrayList<ConverterSetup>,
                                        numTimepoints: Int,
                                        name: String = "Volume",
-                                       vararg voxelDimensions: Float): Volume {
+                                       vararg voxelDimensions: Float,
+                                       block: Volume.() -> Unit = {}): Volume {
         var timepoints = numTimepoints
         var cacheControl: CacheControl? = null
 
@@ -1363,7 +1377,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         tf.addControlPoint(1.0f, rampMax)
         val bg = BoundingGrid()
         bg.node = v
-        return addNode(v)
+        return addNode(v, block = block)
     }
 
     /**
@@ -1375,16 +1389,18 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> Type of the dataset.
      * @return THe node corresponding to the volume just added.
     </T> */
+    @JvmOverloads
     fun <T : RealType<T>> addVolume(sources: List<SourceAndConverter<T>>,
                                     numTimepoints: Int,
                                     name: String = "Volume",
-                                    vararg voxelDimensions: Float): Volume {
+                                    vararg voxelDimensions: Float,
+                                    block: Volume.() -> Unit = {}): Volume {
         var setupId = 0
         val converterSetups = ArrayList<ConverterSetup>()
         for (source in sources) {
             converterSetups.add(BigDataViewer.createConverterSetup(source, setupId++))
         }
-        return addVolume(sources, converterSetups, numTimepoints, name, *voxelDimensions)
+        return addVolume(sources, converterSetups, numTimepoints, name, *voxelDimensions, block = block)
     }
 
     /**
@@ -1399,7 +1415,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     </T> */
     @Suppress("UNCHECKED_CAST")
     fun <T : RealType<T>> updateVolume(image: IterableInterval<T>, name: String,
-                                       voxelDimensions: FloatArray, v: Volume): Node {
+                                       voxelDimensions: FloatArray, v: Volume): Volume {
         val sacs = v.metadata["sources"] as List<SourceAndConverter<T>>?
         val source = sacs!![0].spimSource.getSource(0, 0) // hard coded to timepoint and mipmap 0
         val sCur = Views.iterable(source).cursor()

--- a/src/main/java/sc/iview/SciView.kt
+++ b/src/main/java/sc/iview/SciView.kt
@@ -1147,7 +1147,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     @JvmOverloads
     @Suppress("UNCHECKED_CAST")
     fun addVolume(image: Dataset, voxelDimensions: FloatArray, block: Volume.() -> Unit = {}): Volume {
-        return addVolume<RealType<*>>(image.imgPlus as RandomAccessibleInterval<RealType<*>>, image.name ?: "Volume",
+        return addVolume(image.imgPlus as RandomAccessibleInterval<RealType<*>>, image.name ?: "Volume",
                 *voxelDimensions, block = block)
     }
 
@@ -1168,8 +1168,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the volume
     </T> */
-    @JvmOverloads
-    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray, block: Volume.() -> Unit = {}): Volume {
+    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray, block: Volume.() -> Unit): Volume {
         return addVolume(image, "volume", *voxelDimensions, block = block)
     }
 
@@ -1181,7 +1180,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     </T> */
     @Suppress("UNCHECKED_CAST")
     @Throws(Exception::class)
-    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>): Volume {
+    fun <T : RealType<T>> addVolume(image: IterableInterval<T>): Volume {
         return if (image is RandomAccessibleInterval<*>) {
             addVolume(image as RandomAccessibleInterval<RealType<*>>, "Volume")
         } else {
@@ -1198,7 +1197,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     </T> */
     @Suppress("UNCHECKED_CAST")
     @Throws(Exception::class)
-    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>, name: String = "Volume"): Volume {
+    fun <T : RealType<T>> addVolume(image: IterableInterval<T>, name: String = "Volume"): Volume {
         return if (image is RandomAccessibleInterval<*>) {
             addVolume(image as RandomAccessibleInterval<RealType<*>>, name, 1f, 1f, 1f)
         } else {
@@ -1279,7 +1278,6 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the Volume
     </T> */
-    @JvmName("addVolume1")
     @JvmOverloads
     fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume",
                                     vararg voxelDimensions: Float, block: Volume.() -> Unit = {}): Volume {

--- a/src/main/java/sc/iview/SciView.kt
+++ b/src/main/java/sc/iview/SciView.kt
@@ -576,7 +576,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      */
     @JvmOverloads
     fun addBox(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), size: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR,
-               inside: Boolean = false): Node? {
+               inside: Boolean = false): Box {
         // TODO: use a material from the current palate by default
         val boxmaterial = Material()
         boxmaterial.ambient = Vector3f(1.0f, 0.0f, 0.0f)
@@ -594,7 +594,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return the Node corresponding to the sphere
      */
     @JvmOverloads
-    fun addSphere(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), radius: Float = 1f, color: ColorRGB = DEFAULT_COLOR): Node? {
+    fun addSphere(position: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), radius: Float = 1f, color: ColorRGB = DEFAULT_COLOR): Sphere {
         val material = Material()
         material.ambient = Vector3f(1.0f, 0.0f, 0.0f)
         material.diffuse = Utils.convertToVector3f(color)
@@ -615,7 +615,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param num_segments number of segments to represent the cylinder
      * @return  the Node corresponding to the cylinder
      */
-    fun addCylinder(position: Vector3f, radius: Float, height: Float, num_segments: Int): Node? {
+    fun addCylinder(position: Vector3f, radius: Float, height: Float, num_segments: Int): Cylinder {
         val cyl = Cylinder(radius, height, num_segments)
         cyl.position = position
         return addNode(cyl)
@@ -629,7 +629,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param num_segments number of segments used to represent cone
      * @return  the Node corresponding to the cone
      */
-    fun addCone(position: Vector3f, radius: Float, height: Float, num_segments: Int): Node? {
+    fun addCone(position: Vector3f, radius: Float, height: Float, num_segments: Int): Cone {
         val cone = Cone(radius, height, num_segments, Vector3f(0.0f, 0.0f, 1.0f))
         cone.position = position
         return addNode(cone)
@@ -643,7 +643,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return the Node corresponding to the line
      */
     @JvmOverloads
-    fun addLine(start: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), stop: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR): Node? {
+    fun addLine(start: Vector3f = Vector3f(0.0f, 0.0f, 0.0f), stop: Vector3f = Vector3f(1.0f, 1.0f, 1.0f), color: ColorRGB = DEFAULT_COLOR): Line {
         return addLine(arrayOf(start, stop), color, 0.1)
     }
 
@@ -654,7 +654,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param edgeWidth width of line segments
      * @return the Node corresponding to the line
      */
-    fun addLine(points: Array<Vector3f>, color: ColorRGB, edgeWidth: Double): Node? {
+    fun addLine(points: Array<Vector3f>, color: ColorRGB, edgeWidth: Double): Line {
         val material = Material()
         material.ambient = Vector3f(1.0f, 1.0f, 1.0f)
         material.diffuse = Utils.convertToVector3f(color)
@@ -673,7 +673,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * Add a PointLight source at the origin
      * @return a Node corresponding to the PointLight
      */
-    fun addPointLight(): Node? {
+    fun addPointLight(): PointLight {
         val material = Material()
         material.ambient = Vector3f(1.0f, 0.0f, 0.0f)
         material.diffuse = Vector3f(0.0f, 1.0f, 0.0f)
@@ -762,7 +762,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     @JvmOverloads
     fun addPointCloud(points: Collection<RealLocalizable>,
                       name: String? = "PointCloud",
-                      pointSize : Float = 1.0f): Node? {
+                      pointSize : Float = 1.0f): PointCloud {
         val flatVerts = FloatArray(points.size * 3)
         var k = 0
         for (point in points) {
@@ -790,7 +790,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param pointCloud existing PointCloud to add to scene
      * @return a Node corresponding to the PointCloud
      */
-    fun addPointCloud(pointCloud: PointCloud): Node? {
+    fun addPointCloud(pointCloud: PointCloud): PointCloud {
         pointCloud.setupPointCloud()
         pointCloud.position = Vector3f(0f, 0f, 0f)
         return addNode(pointCloud)
@@ -803,7 +803,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return a Node corresponding to the Node
      */
     @JvmOverloads
-    fun addNode(n: Node?, activePublish: Boolean = true): Node? {
+    fun <N: Node?> addNode(n: N, activePublish: Boolean = true): N {
         n?.let {
             scene.addChild(it)
             objectService.addObject(n)
@@ -828,7 +828,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param scMesh scenery mesh to add to scene
      * @return a Node corresponding to the mesh
      */
-    fun addMesh(scMesh: graphics.scenery.Mesh): Node? {
+    fun addMesh(scMesh: graphics.scenery.Mesh): graphics.scenery.Mesh {
         val material = Material()
         material.ambient = Vector3f(1.0f, 0.0f, 0.0f)
         material.diffuse = Vector3f(0.0f, 1.0f, 0.0f)
@@ -844,7 +844,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param mesh net.imagej.mesh to add to scene
      * @return a Node corresponding to the mesh
      */
-    fun addMesh(mesh: Mesh): Node? {
+    fun addMesh(mesh: Mesh): graphics.scenery.Mesh {
         val scMesh = MeshConverter.toScenery(mesh)
         return addMesh(scMesh)
     }
@@ -1123,7 +1123,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param image image to add as a volume
      * @return a Node corresponding to the Volume
      */
-    fun addVolume(image: Dataset): Node? {
+    fun addVolume(image: Dataset): Volume {
         val voxelDims = FloatArray(image.numDimensions())
         for (d in voxelDims.indices) {
             val inValue = image.axis(d).averageScale(0.0, 1.0)
@@ -1140,7 +1140,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return a Node corresponding to the Volume
      */
     @Suppress("UNCHECKED_CAST")
-    fun addVolume(image: Dataset, voxelDimensions: FloatArray): Node? {
+    fun addVolume(image: Dataset, voxelDimensions: FloatArray): Volume {
         return addVolume<RealType<*>>(image.imgPlus as RandomAccessibleInterval<RealType<*>>, image.name ?: "Volume",
                 *voxelDimensions)
     }
@@ -1151,7 +1151,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the volume
     </T> */
-    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume"): Node? {
+    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume"): Volume {
         return addVolume(image, name, 1f, 1f, 1f)
     }
 
@@ -1161,7 +1161,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @param <T> pixel type of image
      * @return a Node corresponding to the volume
     </T> */
-    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray): Node? {
+    fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, voxelDimensions: FloatArray): Volume {
         return addVolume(image, "volume", *voxelDimensions)
     }
 
@@ -1173,7 +1173,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     </T> */
     @Suppress("UNCHECKED_CAST")
     @Throws(Exception::class)
-    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>): Node? {
+    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>): Volume {
         return if (image is RandomAccessibleInterval<*>) {
             addVolume(image as RandomAccessibleInterval<RealType<*>>, "Volume")
         } else {
@@ -1190,7 +1190,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     </T> */
     @Suppress("UNCHECKED_CAST")
     @Throws(Exception::class)
-    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>, name: String = "Volume"): Node? {
+    fun <T : RealType<T>?> addVolume(image: IterableInterval<T>, name: String = "Volume"): Volume {
         return if (image is RandomAccessibleInterval<*>) {
             addVolume(image as RandomAccessibleInterval<RealType<*>>, name, 1f, 1f, 1f)
         } else {
@@ -1254,7 +1254,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     fun <T : RealType<T>> addVolume(sac: SourceAndConverter<T>,
                                     numTimepoints: Int,
                                     name: String = "Volume",
-                                    vararg voxelDimensions: Float): Node? {
+                                    vararg voxelDimensions: Float): Volume {
         val sources: MutableList<SourceAndConverter<T>> = ArrayList()
         sources.add(sac)
         return addVolume(sources, numTimepoints, name, *voxelDimensions)
@@ -1270,7 +1270,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * @return a Node corresponding to the Volume
     </T> */
     fun <T : RealType<T>> addVolume(image: RandomAccessibleInterval<T>, name: String = "Volume",
-                                    vararg voxelDimensions: Float): Node? {
+                                    vararg voxelDimensions: Float): Volume {
         //log.debug( "Add Volume " + name + " image: " + image );
         val dimensions = LongArray(image.numDimensions())
         image.dimensions(dimensions)
@@ -1300,7 +1300,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
             sources.add(source)
         }
         val v = addVolume(sources, numTimepoints, name, *voxelDimensions)
-        v?.metadata?.set("RandomAccessibleInterval", image)
+        v.metadata.set("RandomAccessibleInterval", image)
         return v
     }
 
@@ -1320,7 +1320,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
                                        converterSetups: ArrayList<ConverterSetup>,
                                        numTimepoints: Int,
                                        name: String = "Volume",
-                                       vararg voxelDimensions: Float): Node? {
+                                       vararg voxelDimensions: Float): Volume {
         var timepoints = numTimepoints
         var cacheControl: CacheControl? = null
 
@@ -1378,7 +1378,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
     fun <T : RealType<T>> addVolume(sources: List<SourceAndConverter<T>>,
                                     numTimepoints: Int,
                                     name: String = "Volume",
-                                    vararg voxelDimensions: Float): Node? {
+                                    vararg voxelDimensions: Float): Volume {
         var setupId = 0
         val converterSetups = ArrayList<ConverterSetup>()
         for (source in sources) {

--- a/src/main/java/sc/iview/commands/demo/advanced/LoadCremiDatasetAndNeurons.kt
+++ b/src/main/java/sc/iview/commands/demo/advanced/LoadCremiDatasetAndNeurons.kt
@@ -112,19 +112,20 @@ class LoadCremiDatasetAndNeurons: Command {
             cursor.get().set(0)
         }
 
-        val volume = sciview.addVolume(nai.third, files.first().name) as? Volume
-        volume?.origin = Origin.FrontBottomLeft
-        volume?.scale = Vector3f(0.08f, 0.08f, 5.0f)
-        volume?.transferFunction = TransferFunction.ramp(0.3f, 0.1f, 0.1f)
-        // min 20, max 180, color map fire
-
-        volume?.transferFunction?.addControlPoint(0.3f, 0.5f)
-        volume?.transferFunction?.addControlPoint(0.8f, 0.01f)
-        volume?.converterSetups?.get(0)?.setDisplayRange(20.0, 220.0)
-        val colormap = lut.loadLUT(lut.findLUTs().get("Grays.lut"))
+        val colormapVolume = lut.loadLUT(lut.findLUTs().get("Grays.lut"))
         val colormapNeurons = lut.loadLUT(lut.findLUTs().get("Fire.lut"))
 
-        volume?.colormap = Colormap.fromColorTable(colormap)
+        sciview.addVolume(nai.third, files.first().name) {
+            origin = Origin.FrontBottomLeft
+            scale = Vector3f(0.08f, 0.08f, 5.0f)
+            transferFunction = TransferFunction.ramp(0.3f, 0.1f, 0.1f)
+            // min 20, max 180, color map fire
+
+            transferFunction.addControlPoint(0.3f, 0.5f)
+            transferFunction.addControlPoint(0.8f, 0.01f)
+            converterSetups.get(0).setDisplayRange(20.0, 220.0)
+            colormap = Colormap.fromColorTable(colormapVolume)
+        }
 
 
         task.status = "Creating labeling"
@@ -156,12 +157,12 @@ class LoadCremiDatasetAndNeurons: Command {
             log.info("Converting neuron ${i + 1}/${largestNeuronLabels.size} to scenery format...")
             // Convert the mesh into a scenery mesh for visualization
             val mesh = MeshConverter.toScenery(m, false, flipWindingOrder = true)
-            mesh.scale = Vector3f(0.01f, 0.01f, 0.06f)
-            mesh.material.diffuse = colormapNeurons.lookupARGB(0.0, 255.0, kotlin.random.Random.nextDouble(0.0, 255.0)).toRGBColor().xyz()
-            mesh.material.roughness = 0.0f
-
-            mesh.name = "Neuron $i"
-            sciview.addNode(mesh)
+            sciview.addNode(mesh) {
+                scale = Vector3f(0.01f, 0.01f, 0.06f)
+                material.diffuse = colormapNeurons.lookupARGB(0.0, 255.0, kotlin.random.Random.nextDouble(0.0, 255.0)).toRGBColor().xyz()
+                material.roughness = 0.0f
+                name = "Neuron $i"
+            }
             val completion = 10.0f + ((i+1)/largestNeuronLabels.size.toFloat())*90.0f
             task.completion = completion
         }

--- a/src/main/java/sc/iview/commands/demo/animation/GameOfLife3D.kt
+++ b/src/main/java/sc/iview/commands/demo/animation/GameOfLife3D.kt
@@ -292,7 +292,7 @@ class GameOfLife3D : Command {
         if (volume == null) {
             name = "Life Simulation"
             voxelDims = floatArrayOf(1f, 1f, 1f)
-            volume = sciView.addVolume(img as RandomAccessibleInterval<UnsignedByteType>, name, *voxelDims) as Volume?
+            volume = sciView.addVolume(img as RandomAccessibleInterval<UnsignedByteType>, name, *voxelDims)
             val bg = BoundingGrid()
             bg.node = volume
 

--- a/src/main/java/sc/iview/commands/demo/animation/GameOfLife3D.kt
+++ b/src/main/java/sc/iview/commands/demo/animation/GameOfLife3D.kt
@@ -292,15 +292,16 @@ class GameOfLife3D : Command {
         if (volume == null) {
             name = "Life Simulation"
             voxelDims = floatArrayOf(1f, 1f, 1f)
-            volume = sciView.addVolume(img as RandomAccessibleInterval<UnsignedByteType>, name, *voxelDims)
-            val bg = BoundingGrid()
-            bg.node = volume
+            volume = sciView.addVolume(img as RandomAccessibleInterval<UnsignedByteType>, name, *voxelDims) {
+                val bg = BoundingGrid()
+                bg.node = this
 
-            volume!!.transferFunction.addControlPoint(0.0f, 0.0f)
-            volume!!.transferFunction.addControlPoint(0.4f, 0.3f)
-            volume!!.scale = Vector3f(10.0f, 10.0f, 10.0f)
-            volume!!.name = "Game of Life 3D"
-            sciView.centerOnNode(volume)
+                transferFunction.addControlPoint(0.0f, 0.0f)
+                transferFunction.addControlPoint(0.4f, 0.3f)
+                scale = Vector3f(10.0f, 10.0f, 10.0f)
+                name = "Game of Life 3D"
+                sciView.centerOnNode(this)
+            }
 
             // NB: Create dynamic metadata lazily.
             val commandInfo: CommandInfo = commandService.getCommand(javaClass)

--- a/src/main/java/sc/iview/commands/demo/animation/VolumeTimeseriesDemo.kt
+++ b/src/main/java/sc/iview/commands/demo/animation/VolumeTimeseriesDemo.kt
@@ -68,17 +68,18 @@ class VolumeTimeseriesDemo : Command {
         val dataset = makeDataset()
 
         val bdv = BdvFunctions.show(dataset, "test")
-        val v = sciView.addVolume(dataset, floatArrayOf(1f, 1f, 1f, 1f)) as Volume?
-        v?.pixelToWorldRatio = 10f
-        v?.name = "Volume Render Demo"
-        v?.dirty = true
-        v?.needsUpdate = true
+        sciView.addVolume(dataset, floatArrayOf(1f, 1f, 1f, 1f)) {
+            pixelToWorldRatio = 10f
+            name = "Volume Render Demo"
+            dirty = true
+            needsUpdate = true
 
-        bdv.bdvHandle.viewerPanel.addTimePointListener { t ->
-            v?.goToTimepoint(t.coerceIn(0, v.timepointCount-1))
+            bdv.bdvHandle.viewerPanel.addTimePointListener { t ->
+                goToTimepoint(t.coerceIn(0, timepointCount-1))
+            }
+
+            sciView.setActiveNode(this)
         }
-
-        sciView.setActiveNode(v)
         sciView.centerOnNode(sciView.activeNode)
     }
 

--- a/src/main/java/sc/iview/commands/demo/basic/VolumeRenderDemo.kt
+++ b/src/main/java/sc/iview/commands/demo/basic/VolumeRenderDemo.kt
@@ -89,11 +89,12 @@ class VolumeRenderDemo : Command {
             log.error(exc)
             return
         }
-        val v = sciView.addVolume(cube, floatArrayOf(1f, 1f, 1f))
-        v.pixelToWorldRatio = 10f
-        v.name = "Volume Render Demo"
-        v.dirty = true
-        v.needsUpdate = true
+        val v = sciView.addVolume(cube, floatArrayOf(1f, 1f, 1f)) {
+            pixelToWorldRatio = 10f
+            name = "Volume Render Demo"
+            dirty = true
+            needsUpdate = true
+        }
         if (iso) {
             val isoLevel = 1
 

--- a/src/main/java/sc/iview/commands/demo/basic/VolumeRenderDemo.kt
+++ b/src/main/java/sc/iview/commands/demo/basic/VolumeRenderDemo.kt
@@ -89,7 +89,7 @@ class VolumeRenderDemo : Command {
             log.error(exc)
             return
         }
-        val v = sciView.addVolume(cube, floatArrayOf(1f, 1f, 1f)) as Volume
+        val v = sciView.addVolume(cube, floatArrayOf(1f, 1f, 1f))
         v.pixelToWorldRatio = 10f
         v.name = "Volume Render Demo"
         v.dirty = true

--- a/src/main/java/sc/iview/commands/edit/add/AddVolume.kt
+++ b/src/main/java/sc/iview/commands/edit/add/AddVolume.kt
@@ -79,10 +79,10 @@ class AddVolume : Command {
     override fun run() {
         if (inheritFromImage) {
             val n = sciView.addVolume(image)
-            n?.name = image.name ?: "Volume"
+            n.name = image.name ?: "Volume"
         } else {
             val n = sciView.addVolume(image, floatArrayOf(voxelWidth, voxelHeight, voxelDepth))
-            n?.name = image.name ?: "Volume"
+            n.name = image.name ?: "Volume"
         }
     }
 

--- a/src/main/java/sc/iview/commands/edit/add/AddVolume.kt
+++ b/src/main/java/sc/iview/commands/edit/add/AddVolume.kt
@@ -78,11 +78,13 @@ class AddVolume : Command {
 
     override fun run() {
         if (inheritFromImage) {
-            val n = sciView.addVolume(image)
-            n.name = image.name ?: "Volume"
+            sciView.addVolume(image) {
+                name = image.name ?: "Volume"
+            }
         } else {
-            val n = sciView.addVolume(image, floatArrayOf(voxelWidth, voxelHeight, voxelDepth))
-            n.name = image.name ?: "Volume"
+            sciView.addVolume(image, floatArrayOf(voxelWidth, voxelHeight, voxelDepth)) {
+                name = image.name ?: "Volume"
+            }
         }
     }
 


### PR DESCRIPTION
- Makes `add` methods return the type of the added node if possible, e.g. `addVolume(): Volume` instead of `addVolume(): Node?`
- Adds a lambda block parameter to `add` methods to allow something like this:
```
sciView.addVolume(dataset, floatArrayOf(1f, 1f, 1f, 1f)) {
    pixelToWorldRatio = 10f
    name = "Volume Render Demo"
    dirty = true
}
```
.. instead of 
```
val v = sciView.addVolume(dataset, floatArrayOf(1f, 1f, 1f, 1f))
v.pixelToWorldRatio = 10f
v.name = "Volume Render Demo"
v.dirty = true
```