### PR TITLE
Update FlatLaf dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>com.formdev</groupId>
 			<artifactId>flatlaf</artifactId>
-			<version>0.38</version>
+			<version>1.1</version>
 		</dependency>
 
 		<!-- SciJava dependencies -->


### PR DESCRIPTION
This is breaking L&F changes in SNT that [declares](https://github.com/morphonets/SNT/blob/2bd09b8e5d1b5a44b44d9379a430c801d8e51b5f/pom.xml#L166-L168) the latest FlatLaf version.
Somehow, when subscribed to both SNT and sciview update sites, the updater retains the outdated artifact, so this is the quickest way to fix it. 
Either way, _many_ improvements are in place with version 1.1, so it makes sense to update.
More details here: https://github.com/JFormDesigner/FlatLaf/issues/280