### PR TITLE
Fix BigVolumeViewer version in Gradle build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ val sceneryVersion = "4a0c1f7"
 "ui-behaviour"("2.0.3")
 "imagej-mesh"("0.8.1")
 "bigdataviewer-vistools"("1.0.0-beta-21")
-"bigvolumeviewer"("0.1.8") // added from Gradle conversion
+//"bigvolumeviewer"("0.1.8") // added from Gradle conversion
 
 "kotlin"("1.4.20")
 "kotlinx-coroutines-core"("1.3.9")
@@ -116,7 +116,8 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     testImplementation(kotlin("test-junit"))
 
-    sciJava("sc.fiji"["bigdataviewer-core", "bigdataviewer-vistools", "bigvolumeviewer"])
+    sciJava("sc.fiji"["bigdataviewer-core", "bigdataviewer-vistools"])
+    implementation("com.github.skalarproduktraum:jogl-minimal:1c86442")
 
     // this apparently is still necessary
     implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
+org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,5 +6,6 @@ gradle.rootProject {
     description = "Scenery-backed 3D visualization package for ImageJ."
 }
 
-if (System.getProperty("CI") == "false")
+if (System.getProperty("CI").toBoolean() != true && System.getenv("CI").toBoolean() != true) {
     includeBuild("../scenery")
+}


### PR DESCRIPTION
This PR fixes the BigVolumeViewer version in the Gradle build to the correct jitpack one, and removes the reference to release version 0.1.8. This can be changed back after tpietzsch/jogl-minimal#14 is merged. See also scenerygraphics/scenery#402.

Together with the scenery PR, this PR solves the issue of the volume demos silently failing.