### PR TITLE
Gradle catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     sciview.sign
     id("org.jetbrains.dokka") version ktVersion
     jacoco
-    id("sciJava.platform") version "30.0.0+14"
+    id("sciJava.platform") version "30.0.0+15"
 }
 
 repositories {
@@ -33,12 +33,10 @@ dependencies {
     // Graphics dependencies
 
     annotationProcessor(sciJava.common)
-    kapt(sciJava.common) {
-        exclude("org.lwjgl")
-    }
+    kapt(sciJava.common)
 
-    val scenery = "c6080e1"
-    api("graphics.scenery:scenery:$scenery") //{ constraints { version { strictly("f6b4e75") }  } }
+    val scenery = "96e8a96"
+    implementation("graphics.scenery:scenery:$scenery") // { version { strictly(scenery) } }
     // check if build is triggered
     // if not, uncomment this only to trigger it
 //    api("com.github.scenerygraphics:scenery:$scenery")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     kapt(sciJava.common)
 
     val scenery = "96e8a96"
-    implementation("graphics.scenery:scenery:$scenery") // { version { strictly(scenery) } }
+    api("graphics.scenery:scenery:$scenery") // { version { strictly(scenery) } }
     // check if build is triggered
     // if not, uncomment this only to trigger it
 //    api("com.github.scenerygraphics:scenery:$scenery")
@@ -212,3 +212,4 @@ artifacts {
 }
 
 java.withSourcesJar()
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.kotlin.dsl.implementation
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import sciJava.*
+import sciview.implementation
 import java.net.URL
 
 plugins {
@@ -14,28 +15,26 @@ plugins {
     id("com.github.elect86.sciJava") version "0.0.4"
     id("org.jetbrains.dokka") version ktVersion
     jacoco
-    idea
+    id("sciJava.platform") version "30.0.0+11"
 }
 
 repositories {
     mavenCentral()
     jcenter()
-    maven("https://jitpack.io")
     maven("https://maven.scijava.org/content/groups/public")
+    maven("https://raw.githubusercontent.com/kotlin-graphics/mary/master")
+    maven("https://jitpack.io")
 }
 
-val sceneryVersion = "4a0c1f7"
 // here we set some versions
-//"scijava-common"("2.84.0")
-"ui-behaviour"("2.0.3")
-"imagej-mesh"("0.8.1")
-"bigdataviewer-vistools"("1.0.0-beta-21")
+//"ui-behaviour"("2.0.3")
+//"imagej-mesh"("0.8.1")
+//"bigdataviewer-vistools"("1.0.0-beta-21")
 //"bigvolumeviewer"("0.1.8") // added from Gradle conversion
 
-"kotlin"("1.4.20")
-"kotlinx-coroutines-core"("1.3.9")
-
 dependencies {
+
+    //    implementation(platform("sciJava:platform:30.0.0+6"))
 
     // Graphics dependencies
 
@@ -43,46 +42,54 @@ dependencies {
     annotationProcessor(sciJavaCommon)
     kapt(sciJavaCommon)
 
-    api("graphics.scenery:scenery:$sceneryVersion")
-//    api("com.github.scenerygraphics:scenery:$sceneryVersion")
+    //    api("graphics.scenery:scenery:861b4bc")
+    api("com.github.scenerygraphics:scenery:861b4bc")
 
-    sciJava("net.clearvolume:cleargl")
-    sciJava("net.clearcontrol:coremem")
-    sciJava("org.jogamp.jogl:jogl-all", native = joglNative)
+    implementation(misc.cleargl)
+    implementation(misc.coreMem)
+    implementation(jogamp.jogl, native = joglNative)
 
     implementation("com.formdev:flatlaf:0.38")
 
     // SciJava dependencies
 
-    sciJava("org.scijava"["scijava-common", "ui-behaviour", "script-editor", "scijava-ui-swing",
-            "scijava-ui-awt", "scijava-search", "scripting-jython"])
-    implementation("org.scijava:scijava-common:2.83.0") {
-        version { strictly("2.83.3") }
-    }
-    sciJava("com.miglayout:miglayout-swing")
+    implementation(sciJava.common) // { version { strictly("2.83.3") } } CHECKME
+    implementation(sciJava.uiBehaviour)
+    implementation(sciJava.scriptEditor)
+    implementation(sciJava.uiSwing)
+    implementation(sciJava.uiAwt)
+    implementation(sciJava.search)
+    implementation(sciJava.scriptingJython)
+    implementation(migLayout.swing)
 
     // ImageJ dependencies
 
-    sciJava("net.imagej") {
-        exclude("org.scijava", "scripting-renjin")
-        exclude("org.scijava", "scripting-jruby")
-    }
-
-    sciJava("net.imagej:imagej-"["common", "mesh", "mesh-io", "ops", "launcher", "ui-swing", "legacy"])
-    sciJava("io.scif:scifio"["", "-bf-compat"])
+    implementation(imagej.core)
+    //    sciJava("net.imagej") {
+    //        exclude("org.scijava", "scripting-renjin")
+    //        exclude("org.scijava", "scripting-jruby")
+    //    }
+    implementation(imagej.common)
+    implementation(imagej.mesh) { version { strictly("0.8.1") } } // FIXME
+    implementation(imagej.meshIo)
+    implementation(imagej.ops)
+    implementation(imagej.launcher)
+    implementation(imagej.uiSwing)
+    implementation(imagej.legacy)
+    implementation(scifio.scifio)
+    implementation(scifio.bfCompat)
 
     // ImgLib2 dependencies
-
-    sciJava("net.imglib2:imglib2"["-roi", ""])
+    implementation(imgLib2.core)
+    implementation(imgLib2.roi)
 
     // Math dependencies
-
-    sciJava("org.apache.commons:commons-math3")
-    sciJava("org.joml")
+    implementation(commons.math3)
+    implementation(misc.joml)
 
     // Kotlin dependencies
 
-    sciJava("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
 
     // Optional dependencies - for sc.iview.Main only! -->
     //		<dependency>
@@ -104,19 +111,21 @@ dependencies {
 
     // Test scope
 
-    testSciJava("junit")
-    sciJava("net.imagej:ij", test = false)
-    sciJava("net.imglib2:imglib2-ij", test = false)
+    testImplementation(misc.junit4)
+    implementation(imagej.ij)
+    implementation(imgLib2.ij)
 
-
-    sciJava("org.janelia.saalfeldlab:n5"["", "-hdf5", "-imglib2"])
-    sciJava("sc.fiji:spim_data")
+    implementation(n5.core)
+    implementation(n5.hdf5)
+    implementation(n5.imglib2)
+    implementation(bigDataViewer.spimData)
 
     implementation(platform(kotlin("bom")))
     implementation(kotlin("stdlib-jdk8"))
     testImplementation(kotlin("test-junit"))
 
-    sciJava("sc.fiji"["bigdataviewer-core", "bigdataviewer-vistools"])
+    implementation(bigDataViewer.core)
+    implementation(bigDataViewer.visTools)
     implementation("com.github.skalarproduktraum:jogl-minimal:1c86442")
 
     // this apparently is still necessary

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,7 @@
 import org.gradle.kotlin.dsl.implementation
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import sciview.api
 import sciview.implementation
 import sciview.joglNatives
-import sciview.lwjglNatives
 import java.net.URL
 
 plugins {
@@ -28,26 +26,19 @@ repositories {
 
 dependencies {
 
-    //    implementation(platform("sciJava:platform:30.0.0+6"))
-
     // Graphics dependencies
 
     annotationProcessor(sciJava.common)
     kapt(sciJava.common)
 
-    val scenery = "96e8a96"
-    api("graphics.scenery:scenery:$scenery") // { version { strictly(scenery) } }
-    // check if build is triggered
+    val sceneryVersion = "96e8a96"
+    api("graphics.scenery:scenery:$sceneryVersion")
+    // check if build is triggered on https://jitpack.io/#scenerygraphics/sciview `build` tab
     // if not, uncomment this only to trigger it
 //    api("com.github.scenerygraphics:scenery:$scenery")
 
+    // This seams to be still necessary
     implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))
-    //    listOf("", "-glfw", "-jemalloc", "-vulkan", "-opengl", "-openvr", "-xxhash", "-remotery").forEach {
-    //        if (it == "-vulkan")
-    //            implementation("org.lwjgl:lwjgl$it")
-    //        else
-    //            implementation("org.lwjgl:lwjgl$it", lwjglNatives)
-    //    }
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)
@@ -57,7 +48,7 @@ dependencies {
 
     // SciJava dependencies
 
-    implementation(sciJava.common) // { version { strictly("2.83.3") } } CHECKME
+    implementation(sciJava.common)
     implementation(sciJava.uiBehaviour)
     implementation(sciJava.scriptEditor)
     implementation(sciJava.uiSwing)
@@ -94,24 +85,6 @@ dependencies {
     // Kotlin dependencies
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-
-    // Optional dependencies - for sc.iview.Main only! -->
-    //		<dependency>
-    //			<groupId>org.scijava</groupId>
-    //			<artifactId>scijava-plugins-commands</artifactId>
-    //			<scope>runtime</scope>
-    //			<optional>true</optional>
-    //		</dependency>
-    //		<dependency>
-    //			<groupId>net.imagej</groupId>
-    //			<artifactId>imagej-plugins-commands</artifactId>
-    //			<scope>runtime</scope>
-    //			<optional>true</optional>
-    //		</dependency>
-    //		<dependency>
-    //			<groupId>ch.qos.logback</groupId>
-    //			<artifactId>logback-classic</artifactId>
-    //		</dependency>
 
     // Test scope
 
@@ -150,7 +123,6 @@ tasks {
         }
         sourceCompatibility = project.properties["sourceCompatibility"]?.toString() ?: default
     }
-    // https://docs.gradle.org/current/userguide/java_testing.html#test_filtering
     test {
         finalizedBy(jacocoTestReport) // report is always generated after tests run
     }
@@ -178,7 +150,7 @@ tasks {
             xml.isEnabled = true
             html.apply {
                 isEnabled = false
-                //                destination = file("$buildDir/jacocoHtml")
+                //destination = file("$buildDir/jacocoHtml")
             }
         }
         dependsOn(test) // tests are required to run before generating the report
@@ -189,7 +161,7 @@ tasks {
         main = "sc.iview.commands.demo.basic.MeshDemo"
 
         // arguments to pass to the application
-        //    args 'appArg1'
+        //    args("appArg1")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     kapt(sciJavaCommon)
 
     //    api("graphics.scenery:scenery:861b4bc")
-    api("com.github.scenerygraphics:scenery:36fbf8c")
+    api("com.github.scenerygraphics:scenery:937ba10")
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
 import org.gradle.kotlin.dsl.implementation
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import sciJava.*
+import sciview.api
 import sciview.implementation
+import sciview.joglNatives
+import sciview.lwjglNatives
 import java.net.URL
 
 plugins {
@@ -12,7 +13,6 @@ plugins {
     kotlin("kapt") version ktVersion
     sciview.publish
     sciview.sign
-    id("com.github.elect86.sciJava") version "0.0.4"
     id("org.jetbrains.dokka") version ktVersion
     jacoco
     id("sciJava.platform") version "30.0.0+14"
@@ -32,16 +32,28 @@ dependencies {
 
     // Graphics dependencies
 
-    val sciJavaCommon = "org.scijava:scijava-common:${versions["scijava-common"]}"
-    annotationProcessor(sciJavaCommon)
-    kapt(sciJavaCommon)
+    annotationProcessor(sciJava.common)
+    kapt(sciJava.common) {
+        exclude("org.lwjgl")
+    }
 
-    //    api("graphics.scenery:scenery:861b4bc")
-    api("graphics.scenery:scenery:937ba10")
+    val scenery = "c6080e1"
+    api("graphics.scenery:scenery:$scenery") //{ constraints { version { strictly("f6b4e75") }  } }
+    // check if build is triggered
+    // if not, uncomment this only to trigger it
+//    api("com.github.scenerygraphics:scenery:$scenery")
+
+    implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))
+    //    listOf("", "-glfw", "-jemalloc", "-vulkan", "-opengl", "-openvr", "-xxhash", "-remotery").forEach {
+    //        if (it == "-vulkan")
+    //            implementation("org.lwjgl:lwjgl$it")
+    //        else
+    //            implementation("org.lwjgl:lwjgl$it", lwjglNatives)
+    //    }
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)
-    implementation(jogamp.jogl, native = joglNative)
+    implementation(jogamp.jogl, joglNatives)
 
     implementation("com.formdev:flatlaf:0.38")
 
@@ -120,8 +132,6 @@ dependencies {
 
     implementation(bigDataViewer.core)
     implementation(bigDataViewer.visTools)
-
-    implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,12 +26,6 @@ repositories {
     maven("https://jitpack.io")
 }
 
-// here we set some versions
-//"ui-behaviour"("2.0.3")
-//"imagej-mesh"("0.8.1")
-//"bigdataviewer-vistools"("1.0.0-beta-21")
-//"bigvolumeviewer"("0.1.8") // added from Gradle conversion
-
 dependencies {
 
     //    implementation(platform("sciJava:platform:30.0.0+6"))
@@ -43,7 +37,7 @@ dependencies {
     kapt(sciJavaCommon)
 
     //    api("graphics.scenery:scenery:861b4bc")
-    api("com.github.scenerygraphics:scenery:937ba10")
+    api("graphics.scenery:scenery:937ba10")
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)
@@ -126,27 +120,6 @@ dependencies {
 
     implementation(bigDataViewer.core)
     implementation(bigDataViewer.visTools)
-    implementation("com.github.skalarproduktraum:jogl-minimal:1c86442")
-
-    // this apparently is still necessary
-    implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))
-    val os = getCurrentOperatingSystem()
-    val lwjglNatives = "natives-" + when {
-        os.isWindows -> "windows"
-        os.isLinux -> "linux"
-        os.isMacOsX -> "macos"
-        else -> error("invalid")
-    }
-    listOf("", "-glfw", "-jemalloc", "-vulkan", "-opengl", "-openvr", "-xxhash", "-remotery").forEach {
-        implementation("org.lwjgl:lwjgl$it")
-        if (it != "-vulkan")
-            runtimeOnly("org.lwjgl", "lwjgl$it", classifier = lwjglNatives)
-    }
-
-    sciJava("graphics.scenery:spirvcrossj:0.7.0-1.1.106.0")
-    runtimeOnly("graphics.scenery", "spirvcrossj", "0.7.0-1.1.106.0", classifier = lwjglNatives)
-
-    sciJava("net.java.jinput:jinput:2.0.9", native = "natives-all")
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     kapt(sciJavaCommon)
 
     //    api("graphics.scenery:scenery:861b4bc")
-    api("com.github.scenerygraphics:scenery:861b4bc")
+    api("com.github.scenerygraphics:scenery:f24fc10")
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,8 @@ dependencies {
 
     implementation(bigDataViewer.core)
     implementation(bigDataViewer.visTools)
+
+    implementation(platform("org.lwjgl:lwjgl-bom:3.2.3"))
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
 
     // Kotlin dependencies
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
 
     // Optional dependencies - for sc.iview.Main only! -->
     //		<dependency>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     id("com.github.elect86.sciJava") version "0.0.4"
     id("org.jetbrains.dokka") version ktVersion
     jacoco
-    id("sciJava.platform") version "30.0.0+11"
+    id("sciJava.platform") version "30.0.0+14"
 }
 
 repositories {
@@ -43,7 +43,7 @@ dependencies {
     kapt(sciJavaCommon)
 
     //    api("graphics.scenery:scenery:861b4bc")
-    api("com.github.scenerygraphics:scenery:f24fc10")
+    api("com.github.scenerygraphics:scenery:36fbf8c")
 
     implementation(misc.cleargl)
     implementation(misc.coreMem)
@@ -76,7 +76,7 @@ dependencies {
     implementation(imagej.launcher)
     implementation(imagej.uiSwing)
     implementation(imagej.legacy)
-    implementation(scifio.scifio)
+    implementation(scifio.core)
     implementation(scifio.bfCompat)
 
     // ImgLib2 dependencies

--- a/buildSrc/src/main/kotlin/sciview/utils.kt
+++ b/buildSrc/src/main/kotlin/sciview/utils.kt
@@ -18,7 +18,7 @@ fun DependencyHandlerScope.implementation(dep: String, native: String) {
     add("implementation", dep)
     val split = dep.split(':')
     addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
-                                  split[0], split[1], split.getOrNull(3), null,
+                                  split[0], split[1], split.getOrNull(2), null,
                                   native, null, null)
 }
 
@@ -35,7 +35,7 @@ fun DependencyHandlerScope.implementation(dep: String, natives: Array<String>) {
     val split = dep.split(':')
     for (native in natives)
         addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
-                                      split[0], split[1], split.getOrNull(3), null,
+                                      split[0], split[1], split.getOrNull(2), null,
                                       native, null, null)
 }
 

--- a/buildSrc/src/main/kotlin/sciview/utils.kt
+++ b/buildSrc/src/main/kotlin/sciview/utils.kt
@@ -39,6 +39,38 @@ fun DependencyHandlerScope.implementation(dep: String, natives: Array<String>) {
                                       native, null, null)
 }
 
+fun DependencyHandlerScope.api(dep: Provider<MinimalExternalModuleDependency>, native: String) = dep.get().apply {
+    add("api", this)
+    addExternalModuleDependencyTo(this@api, "runtimeOnly",
+                                  module.group, module.name, versionConstraint.displayName, null,
+                                  native, null, null)
+}
+
+fun DependencyHandlerScope.api(dep: String, native: String) {
+    add("api", dep)
+    val split = dep.split(':')
+    addExternalModuleDependencyTo(this@api, "runtimeOnly",
+                                  split[0], split[1], split.getOrNull(2), null,
+                                  native, null, null)
+}
+
+fun DependencyHandlerScope.api(dep: Provider<MinimalExternalModuleDependency>, natives: Array<String>) = dep.get().apply {
+    add("api", this)
+    for (native in natives)
+        addExternalModuleDependencyTo(this@api, "runtimeOnly",
+                                      module.group, module.name, versionConstraint.displayName, null,
+                                      native, null, null)
+}
+
+fun DependencyHandlerScope.api(dep: String, natives: Array<String>) {
+    add("api", dep)
+    val split = dep.split(':')
+    for (native in natives)
+        addExternalModuleDependencyTo(this@api, "runtimeOnly",
+                                      split[0], split[1], split.getOrNull(2), null,
+                                      native, null, null)
+}
+
 val joglNatives = arrayOf("natives-windows-amd64", "natives-linux-i586", "natives-linux-amd64", "natives-macosx-universal")
 val lwjglNatives = arrayOf("natives-windows", "natives-linux", "natives-macos")
 val ffmpegNatives = arrayOf("windows-x86_64", "linux-x86_64", "macosx-x86_64")

--- a/buildSrc/src/main/kotlin/sciview/utils.kt
+++ b/buildSrc/src/main/kotlin/sciview/utils.kt
@@ -1,0 +1,44 @@
+package sciview
+
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.DependencyHandlerScope
+import org.gradle.kotlin.dsl.accessors.runtime.addExternalModuleDependencyTo
+
+// this is the same in both scenery and sciview
+
+fun DependencyHandlerScope.implementation(dep: Provider<MinimalExternalModuleDependency>, native: String) = dep.get().apply {
+    add("implementation", this)
+    addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
+                                  module.group, module.name, versionConstraint.displayName, null,
+                                  native, null, null)
+}
+
+fun DependencyHandlerScope.implementation(dep: String, native: String) {
+    add("implementation", dep)
+    val split = dep.split(':')
+    addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
+                                  split[0], split[1], split.getOrNull(3), null,
+                                  native, null, null)
+}
+
+fun DependencyHandlerScope.implementation(dep: Provider<MinimalExternalModuleDependency>, natives: Array<String>) = dep.get().apply {
+    add("implementation", this)
+    for (native in natives)
+        addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
+                                      module.group, module.name, versionConstraint.displayName, null,
+                                      native, null, null)
+}
+
+fun DependencyHandlerScope.implementation(dep: String, natives: Array<String>) {
+    add("implementation", dep)
+    val split = dep.split(':')
+    for (native in natives)
+        addExternalModuleDependencyTo(this@implementation, "runtimeOnly",
+                                      split[0], split[1], split.getOrNull(3), null,
+                                      native, null, null)
+}
+
+val joglNatives = arrayOf("natives-windows-amd64", "natives-linux-i586", "natives-linux-amd64", "natives-macosx-universal")
+val lwjglNatives = arrayOf("natives-windows", "natives-linux", "natives-macos")
+val ffmpegNatives = arrayOf("windows-x86_64", "linux-x86_64", "macosx-x86_64")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,14 +13,17 @@ plugins {
 rootProject.name = "sciview"
 
 gradle.rootProject {
-    //    group = "scenery"
+    group = "graphics.scenery"
     version = "0.2.0-beta-9-SNAPSHOT"
     description = "Scenery-backed 3D visualization package for ImageJ."
 }
 
-if (System.getProperty("CI").toBoolean() != true && System.getenv("CI").toBoolean() != true)
+val useLocalScenery: String? by extra
+if (System.getProperty("CI").toBoolean() != true
+    && System.getenv("CI").toBoolean() != true
+    && useLocalScenery?.toBoolean() == true)
     if(File("../scenery/build.gradle.kts").exists()) {
-        logger.warn("Including local scenery project instead of version declared in build")
+        logger.warn("Including local scenery project instead of version declared in build, set -PuseLocalScenery=false to use declared version instead.")
         includeBuild("../scenery")
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("sciJava.catalogs") version "30.0.0+64"
+    id("sciJava.catalogs") version "30.0.0+66"
 }
 
 rootProject.name = "sciview"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,4 +26,3 @@ if (System.getProperty("CI").toBoolean() != true
         logger.warn("Including local scenery project instead of version declared in build, set -PuseLocalScenery=false to use declared version instead.")
         includeBuild("../scenery")
     }
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("sciJava.catalogs") version "30.0.0+57"
+    id("sciJava.catalogs") version "30.0.0+64"
 }
 
 rootProject.name = "sciview"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,15 @@
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven("https://raw.githubusercontent.com/kotlin-graphics/mary/master")
+    }
+}
+
+plugins {
+    id("sciJava.catalogs") version "30.0.0+57"
+}
+
 rootProject.name = "sciview"
 
 gradle.rootProject {
@@ -7,5 +19,5 @@ gradle.rootProject {
 }
 
 if (System.getProperty("CI").toBoolean() != true && System.getenv("CI").toBoolean() != true) {
-    includeBuild("../scenery")
+//    includeBuild("../scenery")
 }

--- a/src/main/kotlin/sc/iview/SplashLabel.kt
+++ b/src/main/kotlin/sc/iview/SplashLabel.kt
@@ -95,6 +95,8 @@ class SplashLabel : JPanel(), ItemListener {
             attributes.getValue("Implementation-Build")
         } catch (ioe: IOException) {
             ""
+        } catch (npe: NullPointerException) {
+            ""
         }
         return gitHash
     }


### PR DESCRIPTION
- Gradle 7.0
- Gradle Catalog centralized versions, safe-type dependency accessors
- relying on a more vanilla Gradle api (`::implementation` instead `::sciJava`)
- sciJava plugin alignment (against 30.0.0, with a small [deviation](https://github.com/scenerygraphics/sciview/commit/622d0dba6ab829f7d5b1da0539294bc909ebbfb7#r50038119)), workaround for jitpack issue