### PR TITLE
Add CustomPropertyUI

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -98,6 +98,7 @@ import sc.iview.event.NodeAddedEvent
 import sc.iview.event.NodeChangedEvent
 import sc.iview.event.NodeRemovedEvent
 import sc.iview.process.MeshConverter
+import sc.iview.ui.CustomPropertyUI
 import sc.iview.ui.MainWindow
 import sc.iview.ui.SwingMainWindow
 import sc.iview.ui.TaskManager
@@ -1632,6 +1633,10 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      */
     fun requestPropEditorRefresh(n: Node?) {
         eventService.publish(NodeChangedEvent(n))
+    }
+
+    fun attachCustomPropertyUIToNode(node: Node, ui: CustomPropertyUI) {
+        node.metadata["sciview-inspector-${ui.module.info.name}"] = ui
     }
 
     companion object {

--- a/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
@@ -98,6 +98,10 @@ class GameOfLife3D : InteractiveCommand() {
 
     @Parameter(callback = "pause", style = "group:Game of Life")
     private lateinit var pause: Button
+
+    @Parameter(label = "Activate roflcopter", style = "group:Game of Life")
+    private var roflcopter: Boolean = false
+
     private val w = 64
     private val h = 64
     private val d = 64
@@ -189,19 +193,6 @@ class GameOfLife3D : InteractiveCommand() {
 
     override fun run() {
         randomize()
-        dialog = GenericDialog("Game of Life 3D")
-        dialog!!.addNumericField("Starvation threshold", starvation.toDouble(), 0)
-        dialog!!.addNumericField("Birth threshold", birth.toDouble(), 0)
-        dialog!!.addNumericField("Suffocation threshold", suffocation.toDouble(), 0)
-        dialog!!.addNumericField("Initial saturation % when randomizing", saturation.toDouble(), 0)
-        dialog!!.showDialog()
-        if (dialog!!.wasCanceled()) return
-        starvation = dialog!!.nextNumber.toInt()
-        birth = dialog!!.nextNumber.toInt()
-        suffocation = dialog!!.nextNumber.toInt()
-        saturation = dialog!!.nextNumber.toInt()
-        randomize()
-        play()
     }
 
     // -- Helper methods --
@@ -281,7 +272,8 @@ class GameOfLife3D : InteractiveCommand() {
                     "connectedness",
                     "playSpeed",
                     "play",
-                    "pause"
+                    "pause",
+                    "roflcopter"
                 )
             )
         } else {

--- a/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
@@ -39,10 +39,9 @@ import net.imglib2.img.Img
 import net.imglib2.img.array.ArrayImgs
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import org.joml.Vector3f
-import org.scijava.command.Command
-import org.scijava.command.CommandInfo
-import org.scijava.command.CommandService
+import org.scijava.command.*
 import org.scijava.event.EventHandler
+import org.scijava.module.Module
 import org.scijava.plugin.Menu
 import org.scijava.plugin.Parameter
 import org.scijava.plugin.Plugin
@@ -51,10 +50,11 @@ import org.scijava.widget.NumberWidget
 import sc.iview.SciView
 import sc.iview.commands.MenuWeights
 import sc.iview.event.NodeRemovedEvent
+import sc.iview.ui.CustomPropertyUI
 import java.util.*
 
 /**
- * Conway's Game of Lifein 3D!
+ * Conway's Game of Life in 3D!
  *
  * @author Curtis Rueden
  * @author Kyle Harrington
@@ -65,42 +65,38 @@ import java.util.*
         menu = [Menu(label = "Demo", weight = MenuWeights.DEMO),
                 Menu(label = "Animation", weight = MenuWeights.DEMO_ANIMATION),
                 Menu(label = "Game of Life 3D", weight = MenuWeights.DEMO_ANIMATION_GOL3D)])
-class GameOfLife3D : Command {
+class GameOfLife3D : InteractiveCommand() {
     @Parameter
     private lateinit var sciView: SciView
 
-    @Parameter
-    private lateinit var commandService: CommandService
-
-    @Parameter(label = "Starvation threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
+    @Volatile @Parameter(label = "Starvation threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
     private var starvation = 5
 
-    @Parameter(label = "Birth threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
+    @Volatile @Parameter(label = "Birth threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
     private var birth = 6
 
-    @Parameter(label = "Suffocation threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
+    @Volatile @Parameter(label = "Suffocation threshold", min = "0", max = "26", persist = false, style = "group:Game of Life")
     private var suffocation = 9
 
-    @Parameter(label = "Connectedness", choices = [SIX, EIGHTEEN, TWENTY_SIX], persist = false, style = "group:Game of Life")
+    @Volatile @Parameter(label = "Connectedness", choices = [SIX, EIGHTEEN, TWENTY_SIX], persist = false, style = "group:Game of Life")
     private var connectedness = TWENTY_SIX
 
-    @Parameter(label = "Initial saturation % when randomizing", min = "1", max = "99", style = NumberWidget.SCROLL_BAR_STYLE, persist = false)
+    @Volatile @Parameter(label = "Initial saturation % when randomizing", min = "1", max = "99", style = NumberWidget.SCROLL_BAR_STYLE, persist = false)
     private var saturation = 10
 
-    //    @Parameter(label = "Play speed", min = "1", max="100", style = NumberWidget.SCROLL_BAR_STYLE, persist = false)
-    private val playSpeed = 10
+    @Volatile @Parameter(label = "Play speed", min = "1", max="100", style = NumberWidget.SCROLL_BAR_STYLE + ",group:Game of Life", persist = false)
+    private var playSpeed: Int = 10
 
-    //
     @Parameter(callback = "iterate")
     private lateinit var iterate: Button
 
     @Parameter(callback = "randomize")
     private lateinit var randomize: Button
 
-    @Parameter(callback = "play")
+    @Parameter(callback = "play", style = "group:Game of Life")
     private lateinit var play: Button
 
-    @Parameter(callback = "pause")
+    @Parameter(callback = "pause", style = "group:Game of Life")
     private lateinit var pause: Button
     private val w = 64
     private val h = 64
@@ -158,7 +154,6 @@ class GameOfLife3D : Command {
         // compute the new image field
         val access = img!!.randomAccess()
 
-        //RandomAccess<UnsignedByteType> access = ((SourceAndConverter) ((Volume.VolumeDataSource.RAIISource) volume.getDataSource()).getSources().get(0)).getSpimSource().getSource(0, 0).randomAccess();
         for (z in 0 until d) {
             for (y in 0 until h) {
                 for (x in 0 until w) {
@@ -169,10 +164,10 @@ class GameOfLife3D : Command {
                     access.setPosition(y, 2)
                     if (alive(access)) {
                         // Living cell stays alive within (starvation, suffocation).
-                        bits[i] = n > starvation && n < suffocation
+                        bits[i] = n in (starvation + 1) until suffocation
                     } else {
                         // New cell forms within [birth, suffocation).
-                        bits[i] = n >= birth && n < suffocation
+                        bits[i] = n in birth until suffocation
                     }
                 }
             }
@@ -189,17 +184,6 @@ class GameOfLife3D : Command {
             cursor.get().set(if (alive) ALIVE else DEAD)
         }
 
-//        for( int z = 0; z < d; z++ ) {
-//            for( int y = 0; y < h; y++ ) {
-//                for( int x = 0; x < w; x++ ) {
-//                    access.setPosition( x, 0 );
-//                    access.setPosition( y, 1 );
-//                    access.setPosition( y, 2 );
-//                    final boolean alive = bits[z * w * h + y * w + x];
-//                    access.get().set( alive ? ALIVE : DEAD );
-//                }
-//            }
-//        }
         updateVolume()
     }
 
@@ -218,23 +202,6 @@ class GameOfLife3D : Command {
         saturation = dialog!!.nextNumber.toInt()
         randomize()
         play()
-
-//
-//    @Parameter(callback = "iterate")
-//    private Button iterate;
-//
-//    @Parameter(callback = "randomize")
-//    private Button randomize;
-//
-//    @Parameter(callback = "play")
-//    private Button play;
-//
-//    @Parameter(callback = "pause")
-//    private Button pause;
-
-        //play();
-
-        //eventService.subscribe(this);
     }
 
     // -- Helper methods --
@@ -305,30 +272,21 @@ class GameOfLife3D : Command {
             }
 
             // NB: Create dynamic metadata lazily.
-            val commandInfo: CommandInfo = commandService.getCommand(javaClass)
-            volume!!.metadata["sciview-inspector"] = listOf(
-                    commandInfo.getInput("starvation"),
-                    commandInfo.getInput("suffocation"),
-                    commandInfo.getInput("birth"),
-                    commandInfo.getInput("connectedness")
+            volume!!.metadata["sciview-inspector"] = CustomPropertyUI(
+                this,
+                listOf(
+                    "starvation",
+                    "suffocation",
+                    "birth",
+                    "connectedness",
+                    "playSpeed",
+                    "play",
+                    "pause"
+                )
             )
         } else {
             // NB: Name must be unique each time.
             sciView.updateVolume(img as IterableInterval<UnsignedByteType>, name + "-" + ++tick, voxelDims, volume!!)
-
-//            RandomAccessibleIntervalSource<UnsignedByteType> newSource = new RandomAccessibleIntervalSource<UnsignedByteType>(field, new UnsignedByteType(), name + "-" + ++tick);
-//
-//            SourceAndConverter<UnsignedByteType> sourceAndConverter = BigDataViewer.wrapWithTransformedSource(
-//                    new SourceAndConverter<>(newSource, BigDataViewer.createConverterToARGB(new UnsignedByteType())));
-//
-//            ((Volume.VolumeDataSource.RAISource) volume.getDataSource()).getSources().set(0, sourceAndConverter);
-//
-//            volume.getVolumeManager().notifyUpdate(volume);
-//
-//            volume.setDirty(true);
-//            volume.setNeedsUpdate(true);
-//            volume.getVolumeManager().requestRepaint();
-            //volume.getCacheControl().prepareNextFrame();
         }
     }
 

--- a/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/animation/GameOfLife3D.kt
@@ -263,19 +263,20 @@ class GameOfLife3D : InteractiveCommand() {
             }
 
             // NB: Create dynamic metadata lazily.
-            volume!!.metadata["sciview-inspector"] = CustomPropertyUI(
-                this,
-                listOf(
-                    "starvation",
-                    "suffocation",
-                    "birth",
-                    "connectedness",
-                    "playSpeed",
-                    "play",
-                    "pause",
-                    "roflcopter"
-                )
-            )
+            sciView.attachCustomPropertyUIToNode(volume!!,
+                CustomPropertyUI(
+                    this,
+                    listOf(
+                        "starvation",
+                        "suffocation",
+                        "birth",
+                        "connectedness",
+                        "playSpeed",
+                        "play",
+                        "pause",
+                        "roflcopter"
+                    )
+                ))
         } else {
             // NB: Name must be unique each time.
             sciView.updateVolume(img as IterableInterval<UnsignedByteType>, name + "-" + ++tick, voxelDims, volume!!)

--- a/src/main/kotlin/sc/iview/commands/edit/Properties.kt
+++ b/src/main/kotlin/sc/iview/commands/edit/Properties.kt
@@ -40,6 +40,8 @@ import org.scijava.command.Command
 import org.scijava.command.InteractiveCommand
 import org.scijava.event.EventService
 import org.scijava.log.LogService
+import org.scijava.module.Module
+import org.scijava.module.ModuleItem
 import org.scijava.plugin.Parameter
 import org.scijava.plugin.Plugin
 import org.scijava.ui.UIService
@@ -51,6 +53,7 @@ import sc.iview.SciView
 import sc.iview.event.NodeChangedEvent
 import java.io.IOException
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Collectors
 
 /**
@@ -520,10 +523,21 @@ class Properties : InteractiveCommand() {
         return "" + node.name + "[" + count + "]"
     }
 
+    fun addInput(input: ModuleItem<*>, module: Module) {
+        super.addInput(input)
+        inputModuleMaps[input] = module
+    }
+
+    fun getCustomModuleForModuleItem(moduleInfo: ModuleItem<*>): Module? {
+        return inputModuleMaps[moduleInfo]
+    }
+
     companion object {
         private const val PI_NEG = "-3.142"
         private const val PI_POS = "3.142"
         private var dummyColorTable: ColorTable? = null
+
+        private val inputModuleMaps = ConcurrentHashMap<ModuleItem<*>, Module>()
 
         init {
             dummyColorTable = object : ColorTable {

--- a/src/main/kotlin/sc/iview/commands/edit/Properties.kt
+++ b/src/main/kotlin/sc/iview/commands/edit/Properties.kt
@@ -529,7 +529,9 @@ class Properties : InteractiveCommand() {
     }
 
     fun getCustomModuleForModuleItem(moduleInfo: ModuleItem<*>): Module? {
-        return inputModuleMaps[moduleInfo]
+        val custom = inputModuleMaps[moduleInfo]
+        log.info("Custom module found: $custom")
+        return custom
     }
 
     companion object {

--- a/src/main/kotlin/sc/iview/ui/CustomPropertyUI.kt
+++ b/src/main/kotlin/sc/iview/ui/CustomPropertyUI.kt
@@ -1,0 +1,30 @@
+package sc.iview.ui
+
+import org.scijava.module.Module
+import org.scijava.module.ModuleItem
+
+/**
+ * Class for encapsulation of custom UI elements and their [Module]s.
+ *
+ * The constructor of the class performs a check upon initialisation to ensure that
+ * all the [items] given actually do exist as inputs of the given [module].
+ *
+ * @author Ulrik Guenther <hello@ulrik.is>
+ */
+class CustomPropertyUI(val module: Module, val items: List<String>) {
+    init {
+        val inputNames = module.inputs.map { it.key }
+        items.forEach {
+            if(it !in inputNames) {
+                throw IllegalStateException("Input $it not in list of known inputs for module $module.")
+            }
+        }
+    }
+
+    /**
+     * Returns a list of [ModuleItem]s derived from the names given in [items].
+     */
+    fun getMutableInputs(): List<ModuleItem<*>> {
+        return items.map { module.info.getInput(it) }
+    }
+}

--- a/src/main/kotlin/sc/iview/ui/CustomPropertyUI.kt
+++ b/src/main/kotlin/sc/iview/ui/CustomPropertyUI.kt
@@ -16,6 +16,7 @@ class CustomPropertyUI(val module: Module, val items: List<String>) {
         val inputNames = module.inputs.map { it.key }
         items.forEach {
             if(it !in inputNames) {
+                System.err.println("$it is not in known inputs of $module (${inputNames.joinToString(", ")})")
                 throw IllegalStateException("Input $it not in list of known inputs for module $module.")
             }
         }

--- a/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
@@ -137,7 +137,6 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
             inputPanel.component.add(panel.component, "wrap,hidemode 3")
 
             for (item in group.value) {
-                log.info("Adding input ${item.label}/${item.name} ${item.info}")
                 val model = addInput(panel, module, item)
                 if (model != null) models.add(model)
             }

--- a/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
@@ -39,6 +39,7 @@ import org.scijava.plugin.Plugin
 import org.scijava.ui.swing.widget.SwingInputHarvester
 import org.scijava.ui.swing.widget.SwingInputPanel
 import org.scijava.widget.*
+import sc.iview.commands.edit.Properties
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.util.*
@@ -136,6 +137,7 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
             inputPanel.component.add(panel.component, "wrap,hidemode 3")
 
             for (item in group.value) {
+                log.info("Adding input ${item.label}/${item.name} ${item.info}")
                 val model = addInput(panel, module, item)
                 if (model != null) models.add(model)
             }
@@ -151,7 +153,13 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
     // -- Helper methods --
     @Throws(ModuleException::class)
     private fun <T, P, W> addInput(inputPanel: InputPanel<P, W>,
-                                   module: Module, item: ModuleItem<T>): WidgetModel? {
+                                   m: Module, item: ModuleItem<T>): WidgetModel? {
+        val module = if(m is Properties) {
+            m.getCustomModuleForModuleItem(item) ?: m
+        } else {
+            m
+        }
+
         val name = item.name
         if(item.label.contains("[") && item.label.contains("]")) {
             item.label = item.label.substringAfterLast("]")

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -296,13 +296,18 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 currentProperties = p
                 p.setSceneNode(sceneNode)
 
+                val additionalUIs = sceneNode.metadata
+                    .filter { it.key.startsWith("sciview-inspector-") }
+                    .filter { it.value as? CustomPropertyUI != null }
+
                 @Suppress("UNCHECKED_CAST")
-                val additionalUI = sceneNode.metadata["sciview-inspector"] as? CustomPropertyUI
-                if (additionalUI != null) {
-                    log.info("additional UI requested")
-                    for (moduleItem in additionalUI.getMutableInputs()) {
-                        log.info("${moduleItem.name}/${moduleItem.label} added, based on ${additionalUI.module}")
-                        p.addInput(moduleItem, additionalUI.module)
+                additionalUIs.forEach { (name, value) ->
+                    val ui = value as CustomPropertyUI
+                    log.info("Additional UI requested by $name, module ${ui.module.info.name}")
+
+                    for (moduleItem in ui.getMutableInputs()) {
+                        log.info("${moduleItem.name}/${moduleItem.label} added, based on ${ui.module}")
+                        p.addInput(moduleItem, ui.module)
                     }
                 }
 

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -299,9 +299,7 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 @Suppress("UNCHECKED_CAST")
                 val additionalUI = sceneNode.metadata["sciview-inspector"] as? CustomPropertyUI
                 if (additionalUI != null) {
-                    log.info("Module is ${additionalUI.module}")
                     for (moduleItem in additionalUI.getMutableInputs()) {
-                        log.info("Got additional UI item ${moduleItem.name}/${moduleItem.label}")
                         p.addInput(moduleItem, additionalUI.module)
                     }
                 }

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -299,7 +299,9 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 @Suppress("UNCHECKED_CAST")
                 val additionalUI = sceneNode.metadata["sciview-inspector"] as? CustomPropertyUI
                 if (additionalUI != null) {
+                    log.info("additional UI requested")
                     for (moduleItem in additionalUI.getMutableInputs()) {
+                        log.info("${moduleItem.name}/${moduleItem.label} added, based on ${additionalUI.module}")
                         p.addInput(moduleItem, additionalUI.module)
                     }
                 }

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -39,10 +39,7 @@ import org.scijava.Context
 import org.scijava.command.CommandService
 import org.scijava.event.EventHandler
 import org.scijava.log.LogService
-import org.scijava.module.Module
-import org.scijava.module.ModuleException
-import org.scijava.module.ModuleItem
-import org.scijava.module.ModuleService
+import org.scijava.module.*
 import org.scijava.plugin.Parameter
 import org.scijava.plugin.PluginService
 import org.scijava.service.Service
@@ -300,10 +297,12 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 p.setSceneNode(sceneNode)
 
                 @Suppress("UNCHECKED_CAST")
-                val additionalUI = sceneNode.metadata["sciview-inspector"] as? List<ModuleItem<*>>
+                val additionalUI = sceneNode.metadata["sciview-inspector"] as? CustomPropertyUI
                 if (additionalUI != null) {
-                    for (moduleItem in additionalUI) {
-                        p.addInput(moduleItem)
+                    log.info("Module is ${additionalUI.module}")
+                    for (moduleItem in additionalUI.getMutableInputs()) {
+                        log.info("Got additional UI item ${moduleItem.name}/${moduleItem.label}")
+                        p.addInput(moduleItem, additionalUI.module)
                     }
                 }
 


### PR DESCRIPTION
 This PR adds the CustomPropertyUI class in order to enable Commands to add their own UI items to the property inspector. 

Custom UI based on a Command's inputs can be added e.g. as (taken from `GameOfLife3D`)
```kotlin
node.metadata["sciview-inspector"] = CustomPropertyUI(
                this,
                listOf(
                    "starvation",
                    "suffocation",
                    "birth",
                    "connectedness",
                    "playSpeed",
                    "play",
                    "pause"
                )
            )
```

The result then is the following:
![image](https://user-images.githubusercontent.com/586495/123116791-7f61a300-d441-11eb-8034-0df8e9139941.png)
