### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   - "/.*-[0-9]+\\..*/"
 install: true
 git:
-  depth: false
+  depth: 3
 script:
 #- ".travis/build.sh"
 - "python3 .travis/pre_ci.py"


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.