### PR TITLE
jitpack build: Switch to Java 11

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,5 +1,6 @@
-jdk:
-  - openjdk8
+before_install:
+   - sdk install java 11.0.16-tem
+   - sdk use java 11.0.16-tem
 install:
    - echo "Running a custom install command"
    - ./gradlew clean build publishMavenPublicationToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,6 +204,9 @@ tasks {
             // add jvrpn property because it only has runtime native deps
             propertiesNode.appendNode("jvrpn.version", "1.2.0")
 
+            // add correct lwjgl version
+            propertiesNode.appendNode("lwjgl.version", "3.3.1")
+
             val versionedArtifacts = listOf("scenery",
                                             "flatlaf",
                                             "kotlin-stdlib-common",


### PR DESCRIPTION
This PR switches the build process on jitpack to Java 11, using Eclipse Temurin.