### PR TITLE
Remove edgeWidth for Nodes that aren't Line

### DIFF
--- a/src/main/kotlin/sc/iview/commands/edit/Properties.kt
+++ b/src/main/kotlin/sc/iview/commands/edit/Properties.kt
@@ -491,6 +491,8 @@ class Properties : InteractiveCommand() {
 
         if (node is Line){
             edgeWidth = node.edgeWidth.toInt()
+        } else {
+            maybeRemoveInput("edgeWidth", java.lang.Integer::class.java)
         }
 
         name = node.name


### PR DESCRIPTION
Fixes a bug where every node had an edgeWidth attribute in the Properties panel.