### PR TITLE
Add recursive options for node deletion, set LUT, and toggle bounding boxes

### DIFF
--- a/src/main/java/sc/iview/commands/edit/DeleteObject.java
+++ b/src/main/java/sc/iview/commands/edit/DeleteObject.java
@@ -52,6 +52,9 @@ public class DeleteObject implements Command {
     @Parameter
     private SciView sciView;
 
+    @Parameter(label = "Delete children?")
+    private boolean runRecursive = false;
+
 // TODO it would be good if this could continue to use active node but also use an @Parameter by using a callback or sth
 //    @Parameter
 //    private Node node;
@@ -59,7 +62,7 @@ public class DeleteObject implements Command {
     @Override
     public void run() {
         if( sciView.getActiveNode() != null ) {
-            sciView.deleteActiveNode(false);
+            sciView.deleteActiveNode(false, runRecursive);
         }
     }
 

--- a/src/main/kotlin/sc/iview/commands/view/SetLUT.kt
+++ b/src/main/kotlin/sc/iview/commands/view/SetLUT.kt
@@ -31,7 +31,6 @@ package sc.iview.commands.view
 import graphics.scenery.Node
 import net.imglib2.display.ColorTable
 import org.scijava.command.Command
-import org.scijava.command.CommandService
 import org.scijava.command.DynamicCommand
 import org.scijava.plugin.Menu
 import org.scijava.plugin.Parameter
@@ -40,9 +39,7 @@ import org.scijava.prefs.PrefService
 import sc.iview.SciView
 import sc.iview.commands.MenuWeights.VIEW
 import sc.iview.commands.MenuWeights.VIEW_SET_LUT
-import sc.iview.commands.demo.basic.VolumeRenderDemo
 import java.io.IOException
-import java.util.*
 
 
 /**
@@ -67,6 +64,9 @@ class SetLUT : DynamicCommand() {
 
     @Parameter
     private lateinit var prefs: PrefService
+
+    @Parameter
+    private var runRecursive: Boolean = false
 
     protected fun initLutName() {
         lutName = "Fire.lut"
@@ -97,8 +97,9 @@ class SetLUT : DynamicCommand() {
 
     override fun run() {
         node.metadata["sciview.colormapName"] = lutName
-        sciView.setColormap(node, colorTable)
+        sciView.setColormap(node, colorTable, runRecursive)
         // Trigger an update to the UI for the colormap
         sciView.publishNode(node)
     }
+
 }

--- a/src/main/kotlin/sc/iview/commands/view/SetLUT.kt
+++ b/src/main/kotlin/sc/iview/commands/view/SetLUT.kt
@@ -65,7 +65,7 @@ class SetLUT : DynamicCommand() {
     @Parameter
     private lateinit var prefs: PrefService
 
-    @Parameter
+    @Parameter(label = "Apply to child nodes?")
     private var runRecursive: Boolean = false
 
     protected fun initLutName() {

--- a/src/main/kotlin/sc/iview/commands/view/ToggleBoundingGrid.kt
+++ b/src/main/kotlin/sc/iview/commands/view/ToggleBoundingGrid.kt
@@ -30,6 +30,7 @@ package sc.iview.commands.view
 
 import graphics.scenery.BoundingGrid
 import graphics.scenery.Node
+import graphics.scenery.primitives.TextBoard
 import org.scijava.command.Command
 import org.scijava.log.LogService
 import org.scijava.plugin.Menu
@@ -52,7 +53,15 @@ class ToggleBoundingGrid : Command {
     @Parameter
     private lateinit var node: Node
 
-    override fun run() {
+    @Parameter(label = "Apply to child nodes?")
+    private var runRecursive: Boolean = false
+
+    fun toggleBoundingGrid(node: Node) {
+        // We need to skip BoundingGrid and TextBoard otherwise we get an infinite loop
+        if (node is BoundingGrid || node is TextBoard) {
+            return
+        }
+
         val bg = node.children.findLast { it is BoundingGrid } as? BoundingGrid
         if (bg != null) {
             bg.node = null
@@ -61,6 +70,14 @@ class ToggleBoundingGrid : Command {
             val newBg = BoundingGrid()
             newBg.node = node
             sciView.publishNode(newBg)
+        }
+    }
+
+    override fun run() {
+        if (runRecursive) {
+            node.runRecursive({node: Node -> toggleBoundingGrid(node)})
+        } else {
+            toggleBoundingGrid(node)
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/scenerygraphics/sciview/issues/241

When implementing this I found that the only command where there is a clear need is DeleteNode, but SetLUT also makes sense we just don't have examples where a `Volume` is a child of another `Volume`. 

However, I do see the potential for other things that can be applied to Node's recursively, like adjusting position through the inspector.