### PR TITLE
Fix the CI, plus other small updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   linux:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -310,7 +310,7 @@ tasks {
         dokkaSourceSets.configureEach {
             sourceLink {
                 localDirectory.set(file("src/main/kotlin"))
-                remoteUrl.set(URL("https://github.com/scenerygraphics/sciview/tree/master/src/main/kotlin"))
+                remoteUrl.set(URL("https://github.com/scenerygraphics/sciview/tree/main/src/main/kotlin"))
                 remoteLineSuffix.set("#L")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     // Graphics dependencies
 
     // Attention! Manual version increment necessary here!
-    val scijavaCommonVersion = "2.94.1"
+    val scijavaCommonVersion = "2.94.2"
     annotationProcessor("org.scijava:scijava-common:$scijavaCommonVersion")
     kapt("org.scijava:scijava-common:$scijavaCommonVersion") {
         exclude("org.lwjgl")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ jvmTarget=11
 #useLocalScenery=true
 kotlinVersion=1.8.22
 dokkaVersion=1.8.20
-scijavaParentPOMVersion=35.1.1
+scijavaParentPOMVersion=36.0.0

--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1882,11 +1882,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         @Throws(Exception::class)
         fun create(): SciView {
             xinitThreads()
-            val context = Context(ImageJService::class.java, SciJavaService::class.java, SCIFIOService::class.java,
-                ThreadService::class.java, ObjectService::class.java, LogService::class.java, MenuService::class.java,
-                IOService::class.java, EventService::class.java, LUTService::class.java, UnitService::class.java,
-                DatasetIOService::class.java)
-            val objectService = context.getService(ObjectService::class.java)
+            val context = Context(ImageJService::class.java, SciJavaService::class.java, SCIFIOService::class.java)
+            val objectService = context.service(ObjectService::class.java)
             objectService.addObject(Utils.SciviewStandalone())
             val sciViewService = context.service(SciViewService::class.java)
             return sciViewService.orCreateActiveSciView


### PR DESCRIPTION
This branch fixes the GitHub Actions workflow declaration to match the current integration branch name, after the rename from master to main.

It also updates the SciJava BOM version to the latest, version 36.0.0, and simplifies some code in the SciJava context creation.
