### PR TITLE
Fix Maven release issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
         logger.warn("Using local Maven repository as source")
         mavenLocal()
     }
+    maven("https://jitpack.io")
     mavenCentral()
     maven("https://maven.scijava.org/content/groups/public")
 }
@@ -45,7 +46,7 @@ dependencies {
         exclude("org.lwjgl")
     }
 
-    val sceneryVersion = "0.9.0"
+    val sceneryVersion = "055400e"
     api("graphics.scenery:scenery:$sceneryVersion") {
         version { strictly(sceneryVersion) }
         exclude("org.biojava.thirdparty", "forester")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -251,7 +251,8 @@ tasks {
                                             "lwjgl-xxhash",
                                             "lwjgl-remotery",
                                             "lwjgl-spvc",
-                                            "lwjgl-shaderc")
+                                            "lwjgl-shaderc",
+                                            "log4j-1.2-api")
 
             val toSkip = listOf("pom-scijava")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
         exclude("org.lwjgl")
     }
 
-    val sceneryVersion = "055400e"
+    val sceneryVersion = "de3897c"
     api("graphics.scenery:scenery:$sceneryVersion") {
         version { strictly(sceneryVersion) }
         exclude("org.biojava.thirdparty", "forester")
@@ -252,9 +252,12 @@ tasks {
                                             "lwjgl-remotery",
                                             "lwjgl-spvc",
                                             "lwjgl-shaderc",
+                                            "lwjgl-jawt",
                                             "log4j-1.2-api")
 
             val toSkip = listOf("pom-scijava")
+
+            logger.quiet("Adding pom-scijava-managed dependencies for Maven publication:")
 
             configurations.implementation.get().allDependencies.forEach {
                 val artifactId = it.name
@@ -277,7 +280,7 @@ tasks {
                     dependencyNode.appendNode("version", "\${$propertyName}")
 
                     // Custom per artifact tweaks
-                    println(artifactId)
+                    logger.quiet("* ${it.group}:$artifactId with version property \$$propertyName")
                     if ("\\-bom".toRegex().find(artifactId) != null) {
                         dependencyNode.appendNode("type", "pom")
                     }
@@ -377,11 +380,10 @@ tasks {
             }
         }
         .forEach { className ->
-            println("Working on $className")
             val exampleName = className.substringAfterLast(".")
             val exampleType = className.substringBeforeLast(".").substringAfterLast(".")
 
-            println("Registering $exampleName of $exampleType")
+            logger.quiet("Registering $exampleName of $exampleType from $className")
             register<JavaExec>(name = className.substringAfterLast(".")) {
                 classpath = sourceSets.test.get().runtimeClasspath
                 mainClass.set(className)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,7 +259,10 @@ tasks {
 
                     val propertyName = "$artifactId.version"
 
-                    if (versionedArtifacts.contains(artifactId)) {
+                    // we only add our own property if the version is not null,
+                    // as that indicates something managed by the parent POM, where
+                    // we did not specify an explicit version.
+                    if (versionedArtifacts.contains(artifactId) && it.version != null) {
                         // add "<artifactid.version>[version]</artifactid.version>" to pom
                         propertiesNode.appendNode(propertyName, it.version)
                     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,5 +4,10 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven(url="https://dl.bintray.com/kotlin/dokka")
+    gradlePluginPortal()
+//    jcenter() // or maven(url="https://dl.bintray.com/kotlin/dokka")
+}
+
+dependencies {
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
 }

--- a/buildSrc/src/main/kotlin/sciview/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/publish.gradle.kts
@@ -1,5 +1,7 @@
 package sciview
 
+import java.net.URI
+
 //import gradle.kotlin.dsl.accessors._e98ba513b34f86980a981ef4cafb3d49.publishing
 //import org.gradle.kotlin.dsl.`maven-publish`
 
@@ -107,15 +109,14 @@ publishing {
 
     repositories {
         maven {
-//            name = "sonatype" TODO
-//            credentials(PasswordCredentials::class)
-//
-//            val releaseRepo = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-//            val snapshotRepo = "https://oss.sonatype.org/content/repositories/snapshots/"
-//
-//            val snapshot = rootProject.version.toString().endsWith("SNAPSHOT")
-//            url = URI(if (snapshot) snapshotRepo else releaseRepo)
-//            //            url = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+            name = "scijava"
+            credentials(PasswordCredentials::class)
+
+            val releaseRepo = "https://maven.scijava.org/content/repositories/releases/"
+            val snapshotRepo = "https://maven.scijava.org/content/repositories/snapshots/"
+
+            val snapshot = rootProject.version.toString().endsWith("SNAPSHOT")
+            url = URI(if (snapshot) snapshotRepo else releaseRepo)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/sciview/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/publish.gradle.kts
@@ -8,7 +8,8 @@ import java.net.URI
 // configuration of the Maven artifacts
 plugins {
     `maven-publish`
-    //    id("org.jetbrains.dokka")
+    `java-library`
+    id("org.jetbrains.dokka")
 }
 
 val sciviewUrl = "https://github.com/scenerygraphics/sciview"
@@ -21,6 +22,22 @@ publishing {
             version = rootProject.version.toString()
 
             from(components["java"])
+
+            val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
+                dependsOn(tasks.dokkaJavadoc)
+                from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+                archiveClassifier.set("javadoc")
+            }
+
+            val dokkaHtmlJar by tasks.register<Jar>("dokkaHtmlJar") {
+                dependsOn(tasks.dokkaHtml)
+                from(tasks.dokkaHtml.flatMap { it.outputDirectory })
+                archiveClassifier.set("html-doc")
+            }
+
+
+            artifact(dokkaJavadocJar)
+            artifact(dokkaHtmlJar)
 
             // TODO, resolved dependencies versions? https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:resolved_dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 org.gradle.caching=true
 jvmTarget=11
 #useLocalScenery=true
-kotlinVersion=1.8.22
-dokkaVersion=1.8.20
+kotlinVersion=1.9.21
+dokkaVersion=1.9.10
 scijavaParentPOMVersion=36.0.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ rootProject.name = "sciview"
 
 gradle.rootProject {
     group = "sc.iview"
-    version = "0.2.0-beta-9-SNAPSHOT"
+    version = "0.2.0-SNAPSHOT"
     description = "Scenery-backed 3D visualization package for ImageJ."
 }
 


### PR DESCRIPTION
This PR fixes some issues related to versions not declared correctly in Maven publications. Furthermore:
* Gradle metadata is not attached anymore to Maven publications
* on the command line or in `gradle.properties`, the `customVersion` property can be defined. If set to `git`, this will lead to jitpack-like behaviour, where the first seven characters of the current git hash are used as version.
* logging behaviour is improved, with `Command`s discovered by the annotation processor being logged, as well as pom-scijava-managed dependencies