### PR TITLE
SciView: set active node only when centerOnNewNodes is true

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -890,10 +890,10 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
                 Utils.blockWhile({ this.find(n.name) == null }, 20)
                 //System.out.println("find(name) " + find(n.getName()) );
             }
-            // Set new node as active and centered?
-            setActiveNode(n)
+            // Set new node as active and centered
             if (centerOnNewNodes) {
                 centerOnNode(n)
+                setActiveNode(n)
             }
             if (activePublish) {
                 eventService.publish(NodeAddedEvent(n))

--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -890,13 +890,14 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
                 Utils.blockWhile({ this.find(n.name) == null }, 20)
                 //System.out.println("find(name) " + find(n.getName()) );
             }
-            // Set new node as active and centered
-            if (centerOnNewNodes) {
-                centerOnNode(n)
-                setActiveNode(n)
-            }
+
             if (activePublish) {
                 eventService.publish(NodeAddedEvent(n))
+                setActiveNode(n)
+                // Set new node as centered
+                if (centerOnNewNodes) {
+                    centerOnNode(n)
+                }
             }
         }
         return n


### PR DESCRIPTION
This fixes an issue where adding new objects to the scene would be slowed down by the fact that each new node would always be set as the active node. This would also cause excessive log outputs about each active node like:
```
[INFO] Custom module found: null
[INFO] Adding input scaleX/Scale X
[INFO] Custom module found: null
[INFO] Adding input scaleY/Scale Y
[INFO] Custom module found: null
[INFO] Adding input scaleZ/Scale Z
[INFO] Custom module found: null
[INFO] Adding input rotationPhi/Rotation Phi
[INFO] Custom module found: null
[INFO] Adding input rotationTheta/Rotation Theta
[INFO] Custom module found: null
[INFO] Adding input rotationPsi/Rotation Psi
```

With this fix, new nodes are only considered active when `centerOnNewNodes` is set to `true`.