### PR TITLE
Inspector improvements

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -587,7 +587,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * This is automatically called and should not be used directly
      */
     override fun inputSetup() {
-        log.info("Running InputSetup")
+        log.debug("Running InputSetup")
         controls.inputSetup()
     }
 

--- a/src/main/kotlin/sc/iview/commands/edit/Properties.kt
+++ b/src/main/kotlin/sc/iview/commands/edit/Properties.kt
@@ -626,7 +626,7 @@ class Properties : InteractiveCommand() {
 
     fun getCustomModuleForModuleItem(moduleInfo: ModuleItem<*>): Module? {
         val custom = inputModuleMaps[moduleInfo]
-        log.info("Custom module found: $custom")
+        log.debug("Custom module found: $custom")
         return custom
     }
 

--- a/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
@@ -139,7 +139,7 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
             for (item in group.value) {
                 val model = addInput(panel, module, item)
                 if (model != null) {
-                    log.info("Adding input ${item.name}/${item.label}")
+                    log.debug("Adding input ${item.name}/${item.label}")
                     models.add(model)
                 } else {
                     log.error("Model for ${item.name}/${item.label} is null!")

--- a/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingGroupingInputHarvester.kt
@@ -28,6 +28,7 @@
  */
 package sc.iview.ui
 
+import net.miginfocom.swing.MigLayout
 import org.scijava.`object`.ObjectService
 import org.scijava.convert.ConvertService
 import org.scijava.log.LogService
@@ -40,12 +41,18 @@ import org.scijava.ui.swing.widget.SwingInputHarvester
 import org.scijava.ui.swing.widget.SwingInputPanel
 import org.scijava.widget.*
 import sc.iview.commands.edit.Properties
+import sc.iview.ui.SwingNodePropertyEditor.Companion.maybeActivateDebug
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.util.*
 import javax.swing.JLabel
 import javax.swing.JPanel
 
+
+/**
+ * An implementation of [SwingInputHarvester] that allows to build grouped JPanels. In order to define a group,
+ * use the string "group:Something" in the widget's style.
+ */
 @Plugin(type = org.scijava.module.process.PreprocessorPlugin::class, priority = InputHarvester.PRIORITY)
 class SwingGroupingInputHarvester : SwingInputHarvester() {
 
@@ -61,10 +68,21 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
     @Parameter
     private lateinit var convertService: ConvertService
 
-
     // -- InputHarvester methods --
+    /**
+     * Builds the Swing panel, with groups defined by the "group:" string in the widget style.
+     */
     @Throws(ModuleException::class)
     override fun buildPanel(inputPanel: InputPanel<JPanel, JPanel>, module: Module) {
+        buildPanel(inputPanel, module, false)
+    }
+
+    /**
+     * Builds the Swing panel, with groups defined by the "group:" string in the widget style.
+     * If [uiDebug] is set to true, MigLayout's debug drawing will be activated.
+     */
+    @Throws(ModuleException::class)
+    fun buildPanel(inputPanel: InputPanel<JPanel, JPanel>, module: Module, uiDebug: Boolean) {
         val inputs = module.info.inputs()
         val models = ArrayList<WidgetModel>()
         val sortedInputs = inputs.groupBy {
@@ -81,6 +99,10 @@ class SwingGroupingInputHarvester : SwingInputHarvester() {
             val panel = SwingInputPanel()
             val labelPanel = SwingInputPanel()
             val label = JLabel("<html><strong>▼ ${group.key}</strong></html>")
+
+            panel.component.name = "group:${group.key}"
+            panel.component.layout = MigLayout("fillx,wrap 2, gap 2 2, ins 4 4".maybeActivateDebug(uiDebug), "[right]5[fill,grow]")
+            labelPanel.component.layout = MigLayout("fillx,wrap 2, gap 2 2, ins 4 4".maybeActivateDebug(uiDebug), "[right]5[fill,grow]")
 
             label.addMouseListener(object: MouseListener {
                 /**

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -59,6 +59,7 @@ import sc.iview.event.NodeRemovedEvent
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
+import java.awt.Container
 import java.awt.Dimension
 import java.awt.event.ActionEvent
 import java.awt.event.MouseAdapter
@@ -339,21 +340,34 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                 val uiDebug = sciView.hub.get<Settings>()?.get("sciview.DebugUI", false) ?: false
 
                 inputPanel = harvester.createInputPanel()
-                inputPanel.component.layout = MigLayout("fillx,wrap 1,${if(uiDebug) "debug," else { "" } }insets 0 0 0 0", "[right,fill,grow]")
+                inputPanel.component.layout = MigLayout("fillx,wrap 1,insets 0 0 0 0".maybeActivateDebug(uiDebug), "[right,fill,grow]")
+
+                fun changeFont(component: Array<Component>, scale: Float) {
+                    component.forEach {
+                        val newFont = it.font.deriveFont(it.font.size * scale)
+                        it.font = newFont
+
+                        if(it is Container) {
+                            changeFont(it.components, scale)
+                        }
+                    }
+                }
 
                 // Build the panel.
                 try {
-                    harvester.buildPanel(inputPanel, module)
+                    harvester.buildPanel(inputPanel, module, uiDebug)
                     updatePropertiesPanel(inputPanel.component)
 
                     // TODO: This needs to move to a widget and be included in Properties
                     if(sceneNode is Volume) {
+                        // This will find the group that corresponds to the expandable label. If the type of
+                        // the node is indeed Volume, this must exist.
+                        val parent = inputPanel.component.components.find { it.name == "group:Volume" } as? JPanel
                         val tfe = TransferFunctionEditor(sceneNode, sceneNode.name)
                         tfe.preferredSize = Dimension(300, 300)
-                        tfe.layout = MigLayout("fillx,flowy,insets 0 0 0 0, ${if(uiDebug) "debug" else { "" } }", "[right,fill,grow]")
-                        inputPanel.component.add(tfe)
+                        tfe.layout = MigLayout("fillx,flowy,insets 0 0 0 0".maybeActivateDebug(uiDebug), "[right,fill,grow]")
+                        parent?.add(tfe, "span 2, growx")
                     }
-
                 } catch (exc: ModuleException) {
                     log.error(exc)
                     val stackTrace = DebugUtils.getStackTrace(exc)
@@ -361,6 +375,8 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                     textArea.text = "<html><pre>$stackTrace</pre>"
                     updatePropertiesPanel(textArea)
                 }
+
+                changeFont(arrayOf(inputPanel.component), 0.9f)
 
                 updateLock.unlock()
             }
@@ -457,5 +473,22 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
 
     init {
         sciView.scijavaContext!!.inject(this)
+    }
+
+    /**
+     * Companion object for [SwingNodePropertyEditor] with useful utility functions.
+     */
+    companion object {
+        /**
+         * Can be attached to a MigLayout layout constraint string and will activate debug drawing
+         * if [uiDebug] is true.
+         */
+        fun String.maybeActivateDebug(uiDebug: Boolean): String {
+            return if(uiDebug) {
+                "$this, debug"
+            } else {
+                this
+            }
+        }
     }
 }

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -66,6 +66,7 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
+import javax.swing.JCheckBox
 import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JMenuItem
@@ -365,6 +366,11 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                         val parent = inputPanel.component.components.find { it.name == "group:Volume" } as? JPanel
                         val tfe = TransferFunctionEditor(sceneNode, sceneNode.name)
                         tfe.preferredSize = Dimension(300, 300)
+
+                        // the next line is a workaround for a ChangeListener being attached to the Show Histogram checkbox,
+                        // which will continously show/hide the histogram on mouse over. We disable rollover to prevent this.
+                        (tfe.components.find { it is JCheckBox && it.text == "Show Histogram" } as? JCheckBox)?.isRolloverEnabled = false
+
                         tfe.layout = MigLayout("fillx,flowy,insets 0 0 0 0".maybeActivateDebug(uiDebug), "[right,fill,grow]")
                         parent?.add(tfe, "span 2, growx")
                     }


### PR DESCRIPTION
This PR improves the inspector in the following ways:
* the font size is changed to 90% the regular font size to accommodate more controls in the inspector
* the MigLayout managers for all the inspector's constituents are changed to decrease white space in the inspector and make things more compact
* the transfer function editor for volumes now correctly shows up under the Volume group and transforms correctly
* in `SwingGroupingInputHarvester`, the group names are saved to the name of the respective component, such that they are identifiable later on in the lifecycle

![Screenshot 2024-02-20 at 11 03 14](https://github.com/scenerygraphics/sciview/assets/586495/81e93f6f-09d3-47ae-af17-6ee2fd4a6acf)
