### PR TITLE
Add version property for bigvolumeviewer, fix lwjgl version to 3.3.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -236,7 +236,10 @@ tasks {
             propertiesNode.appendNode("jvrpn.version", "1.2.0")
 
             // add correct lwjgl version
-            propertiesNode.appendNode("lwjgl.version", "3.3.1")
+            propertiesNode.appendNode("lwjgl.version", "3.3.3")
+
+            // add bigvolumeviewer version
+            propertiesNode.appendNode("bigvolumeviewer.version", "0.3.3")
 
             val versionedArtifacts = listOf("scenery",
                                             "flatlaf",


### PR DESCRIPTION
The version property for bigvolumeviewer was missing from the pom.xml unfortunately.