### PR TITLE
Bump scenery 0.10.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,6 @@ dependencies {
     implementation("net.imagej:imagej-ops")
 //    implementation("net.imagej:imagej-launcher")
     implementation("net.imagej:imagej-ui-swing")
-    implementation("net.imagej:imagej-legacy")
     implementation("io.scif:scifio")
     implementation("io.scif:scifio-bf-compat")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
         exclude("org.lwjgl")
     }
 
-    val sceneryVersion = "0.9.3"
+    val sceneryVersion = "0.10.1"
     api("graphics.scenery:scenery:$sceneryVersion") {
         version { strictly(sceneryVersion) }
         exclude("org.biojava.thirdparty", "forester")

--- a/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
+++ b/src/main/kotlin/sc/iview/ui/SwingNodePropertyEditor.kt
@@ -364,7 +364,7 @@ class SwingNodePropertyEditor(private val sciView: SciView) : UIComponent<JPanel
                         // This will find the group that corresponds to the expandable label. If the type of
                         // the node is indeed Volume, this must exist.
                         val parent = inputPanel.component.components.find { it.name == "group:Volume" } as? JPanel
-                        val tfe = TransferFunctionEditor(sceneNode, sceneNode.name)
+                        val tfe = TransferFunctionEditor(sceneNode)
                         tfe.preferredSize = Dimension(300, 300)
 
                         // the next line is a workaround for a ChangeListener being attached to the Show Histogram checkbox,


### PR DESCRIPTION
This PR bumps scenery to 0.10.1 and removes the (unnecessary) dependency on legacy ImageJ.