### PR TITLE
Bump scenery to 0.11.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,13 +39,13 @@ dependencies {
     // Graphics dependencies
 
     // Attention! Manual version increment necessary here!
-    val scijavaCommonVersion = "2.97.1"
+    val scijavaCommonVersion = "2.98.0"
     annotationProcessor("org.scijava:scijava-common:$scijavaCommonVersion")
     kapt("org.scijava:scijava-common:$scijavaCommonVersion") {
         exclude("org.lwjgl")
     }
 
-    val sceneryVersion = "0.10.1"
+    val sceneryVersion = "0.11.0"
     api("graphics.scenery:scenery:$sceneryVersion") {
         version { strictly(sceneryVersion) }
         exclude("org.biojava.thirdparty", "forester")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 org.gradle.caching=true
 jvmTarget=21
 #useLocalScenery=true
-kotlinVersion=1.9.21
+kotlinVersion=1.9.23
 dokkaVersion=1.9.10
 scijavaParentPOMVersion=37.0.0

--- a/src/main/kotlin/sc/iview/commands/add/AddOrientationCompass.kt
+++ b/src/main/kotlin/sc/iview/commands/add/AddOrientationCompass.kt
@@ -80,7 +80,9 @@ class AddOrientationCompass : Command {
         axisNode.spatial().rotation = Quaternionf().rotateXYZ(angleX, angleY, angleZ)
         axisNode.ifMaterial {
             diffuse.set(color)
-            depthTest = DepthTest.Always
+            depthTest = true
+            depthOp = DepthTest.Always
+            depthWrite = true
             blending.transparent = true
         }
         val axisCap = Icosphere(AXESBARRADIUS, 2)
@@ -88,7 +90,9 @@ class AddOrientationCompass : Command {
             position = Vector3f(0.0f, axisLength, 0.0f)
         }
         axisCap.material().diffuse.set(color)
-        axisCap.material().depthTest = DepthTest.Always
+        axisCap.material().depthTest = true
+        axisCap.material().depthOp = DepthTest.Always
+        axisCap.material().depthWrite = true
         axisCap.material().blending.transparent = true
         axisNode.addChild(axisCap)
         return axisNode


### PR DESCRIPTION
This PR bumps scenery to 0.11.0, scijava-common to 2.98.0 and Kotlin to 1.9.23. It also adjusts the use of the depth test API in AddOrientationCompass due to an API change in scenery 0.11.0.