### PR TITLE
Avoid calling System.exit from the EDT

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -129,6 +129,7 @@ import java.util.stream.Collectors
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.collections.LinkedHashMap
+import kotlin.concurrent.thread
 import javax.swing.JOptionPane
 import kotlin.math.cos
 import kotlin.math.sin
@@ -1246,7 +1247,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         // if scijavaContext was not created by ImageJ, then system exit
         if( objectService.getObjects(Utils.SciviewStandalone::class.java).size > 0 ) {
             log.info("Was running as sciview standalone, shutting down JVM")
-            System.exit(0)
+            thread { System.exit(0) }
         }
     }
 


### PR DESCRIPTION
Unfortunately, calling it from the EDT creates a deadlock.

SciJava Common registers a JVM shutdown hook thread that calls `dispose()` on AWT windows it manages (e.g. the main ImageJ2 window), but `Window#dispose()` internally runs some logic via `EventQueue.invokeAndWait`.

But meanwhile, the `System.exit` call triggers the shutdown hooks, which use `Thread#join` to wait for them to finish, thus blocking the EDT. So the `invokeAndWait` disposing the window can never finish.

Therefore, as a workaround here, we avoid the problem by exiting the JVM from a new thread instead.

Might fix #538.