### PR TITLE
Update Fiji more nicely

### DIFF
--- a/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
@@ -138,6 +138,12 @@ private fun checksum() {
 private fun update() {
     validateFijiDir()
 
+    val skip = project.properties["fijiUpdateSkip"]?.toString()?.toBoolean() ?: false
+    if (skip) {
+        logger.lifecycle("Skipping Fiji update due to fijiUpdateSkip=true")
+        return
+    }
+
     try {
         runUpdater("add-update-site", updateSite, updateSiteURL)
         runUpdater("update")

--- a/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
@@ -140,7 +140,7 @@ private fun update() {
 
     try {
         runUpdater("add-update-site", updateSite, updateSiteURL)
-        runUpdater("update-force-pristine")
+        runUpdater("update")
     }
     catch (_: Exception) {
         error("Failed to update Fiji")

--- a/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
@@ -239,7 +239,13 @@ private fun populate() {
 }
 
 private fun upload() {
-
+    if (user == null || pass == null) {
+        error("""
+            No credentials available to upload to the update site.
+            Please configure the fijiUpdateSiteUsername and fijiUpdateSitePassword
+            properties in your ~/.gradle/gradle.properties file.
+        """.trimIndent())
+    }
     val dryRun = project.properties["fijiUploadDryRun"]?.toString()?.toBoolean() ?: false
 
     logger.lifecycle("Uploading to Fiji update site $updateSite at $updateSiteURL ${if(dryRun) { " (dry run)" } else { "" }}")

--- a/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
+++ b/buildSrc/src/main/kotlin/sciview/fiji.gradle.kts
@@ -155,6 +155,7 @@ private fun update() {
 
 private fun populate() {
     validateFijiDir()
+    logger.lifecycle("Populating $fijiDir...")
 
     // Parse relevant update site databases. This information is useful
     // for deciding which JAR files to copy, and which ones to leave alone.
@@ -265,7 +266,6 @@ private fun upload() {
 }
 
 private fun validateFijiDir() {
-    logger.lifecycle("Populating $fijiDir...")
     if (!fijiDir.isDirectory) {
         error("No such directory: ${fijiDir.absolutePath}")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,7 @@ fijiTestClass=sc.iview.commands.help.About
 # then be separated by | characters. [GIT_HASH] will be replaced with the current Git hash of the project,
 # or by the value given in the gitHash property. [VERSION_NUMBER] will be replaced by project.version.
 fijiTestClassExpectedOutput=[INFO] SciView was created by Kyle Harrington|[GIT_HASH]|[VERSION_NUMBER]
+# Uncomment the next line if you want the fijiUpdate task to be skipped. This is useful if you plan to repeatedly run fijiPopulate without checking for remote updates every time.
+#fijiUpdateSkip=true
 # Uncomment the next line if you want the fijiUpload task to *simulate* an upload rather than actually doing it.
 #fijiUploadDryRun=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ fijiTestClass=sc.iview.commands.help.About
 # then be separated by | characters. [GIT_HASH] will be replaced with the current Git hash of the project,
 # or by the value given in the gitHash property. [VERSION_NUMBER] will be replaced by project.version.
 fijiTestClassExpectedOutput=[INFO] SciView was created by Kyle Harrington|[GIT_HASH]|[VERSION_NUMBER]
+# Uncomment the next line if you want the fijiUpload task to *simulate* an upload rather than actually doing it.
+#fijiUploadDryRun=true


### PR DESCRIPTION
Rather than using `update-force-pristine`, which clobbers any previously populated new version of sciview in favor of the older currently-on-the-sciview-update-site files, let's use the regular `update` directive, which updates new core libraries, but does not overwrite "Locally modified" files with their older counterparts.

And while at it, let's improve a few other things about the fiji* tasks.
