### PR TITLE
Bump scenery 0.11.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,10 +132,6 @@ dependencies {
         exclude("org.jogamp.gluegen", "gluegen-rt")
     }
 
-    // TODO hacks for testing
-    runtimeOnly("org.jogamp.jogl:jogl-all:2.4.0:natives-macosx-universal")
-    runtimeOnly("com.metsci.ext.org.jogamp.gluegen:gluegen-rt:2.4.0-rc-20200202:natives-macosx-universal")
-
     // OME
     implementation("ome:formats-bsd")
     implementation("ome:formats-gpl")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
         exclude("org.lwjgl")
     }
 
-    val sceneryVersion = "0.11.1"
+    val sceneryVersion = "0.11.2"
     api("graphics.scenery:scenery:$sceneryVersion") {
         version { strictly(sceneryVersion) }
         exclude("org.biojava.thirdparty", "forester")


### PR DESCRIPTION
This PR bumps scenery to 0.11.2 and removes some superfluous dependencies (👀  @kephale 😂).