### PR TITLE
Instancing benchmark demo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -350,50 +350,30 @@ tasks {
         dependsOn(test) // tests are required to run before generating the report
     }
 
-    register("runMain", JavaExec::class.java) {
-        classpath = sourceSets.main.get().runtimeClasspath
+    fun registerTask(name: String, className: String, propertyPrefix: String) {
 
-        mainClass.set("sc.iview.Main")
+        register(name, JavaExec::class.java) {
+            classpath = sourceSets.main.get().runtimeClasspath
 
-        val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("scenery.") }
+            mainClass.set(className)
 
-        val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
-        allJvmArgs = if (additionalArgs != null) {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
-        } else {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
+            val props = System.getProperties().filter { (k, _) -> k.toString().startsWith(propertyPrefix) }
+
+            val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
+            allJvmArgs = if (additionalArgs != null) {
+                allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
+            } else {
+                allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
+            }
         }
     }
 
-    register("runImageJMain", JavaExec::class.java) {
-        classpath = sourceSets.main.get().runtimeClasspath
+    registerTask("runMain", "sc.iview.Main", "scenery.")
 
-        mainClass.set("sc.iview.ImageJMain")
+    registerTask("runImageJMain", "sc.iview.ImageJMain", "scenery.")
 
-        val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("scenery.") }
+    registerTask("runInstancingBenchmark", "sc.iview.commands.demo.advanced.InstancingBenchmark", "sciview.benchmark.")
 
-        val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
-        allJvmArgs = if (additionalArgs != null) {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
-        } else {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
-        }
-    }
-
-    register("runInstancingBenchmark", JavaExec::class.java) {
-        classpath = sourceSets.main.get().runtimeClasspath
-
-        mainClass.set("sc.iview.commands.demo.advanced.InstancingBenchmark")
-
-        val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("sciview.benchmark.") }
-
-        val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
-        allJvmArgs = if (additionalArgs != null) {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
-        } else {
-            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
-        }
-    }
 
     sourceSets.main.get().allSource.files
         .filter { it.path.contains("demo") && (it.name.endsWith(".kt") || it.name.endsWith(".java")) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -380,6 +380,21 @@ tasks {
         }
     }
 
+    register("runInstancingBenchmark", JavaExec::class.java) {
+        classpath = sourceSets.main.get().runtimeClasspath
+
+        mainClass.set("sc.iview.commands.demo.advanced.InstancingBenchmark")
+
+        val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("sciview.benchmark.") }
+
+        val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
+        allJvmArgs = if (additionalArgs != null) {
+            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
+        } else {
+            allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
+        }
+    }
+
     sourceSets.main.get().allSource.files
         .filter { it.path.contains("demo") && (it.name.endsWith(".kt") || it.name.endsWith(".java")) }
         .map {
@@ -395,20 +410,22 @@ tasks {
             val exampleType = className.substringBeforeLast(".").substringAfterLast(".")
 
             logger.info("Registering $exampleName of $exampleType from $className")
-            register<JavaExec>(name = className.substringAfterLast(".")) {
-                classpath = sourceSets.test.get().runtimeClasspath
-                mainClass.set(className)
-                group = "demos.$exampleType"
+            val name = className.substringAfterLast(".")
+            if (name != "InstancingBenchmark")
+                register<JavaExec>(name = className.substringAfterLast(".")) {
+                    classpath = sourceSets.test.get().runtimeClasspath
+                    mainClass.set(className)
+                    group = "demos.$exampleType"
 
-                val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("scenery.") }
+                    val props = System.getProperties().filter { (k, _) -> k.toString().startsWith("scenery.") }
 
-                val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
-                allJvmArgs = if (additionalArgs != null) {
-                    allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
-                } else {
-                    allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
+                    val additionalArgs = System.getenv("SCENERY_JVM_ARGS")
+                    allJvmArgs = if (additionalArgs != null) {
+                        allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") } + additionalArgs
+                    } else {
+                        allJvmArgs + props.flatMap { (k, v) -> listOf("-D$k=$v") }
+                    }
                 }
-            }
         }
 
     register<JavaExec>(name = "run") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -350,9 +350,10 @@ tasks {
         dependsOn(test) // tests are required to run before generating the report
     }
 
-    fun registerTask(name: String, className: String, propertyPrefix: String) {
+    fun registerTask(name: String, className: String, propertyPrefix: String, taskGroup: String = "other") {
 
         register(name, JavaExec::class.java) {
+            group = taskGroup
             classpath = sourceSets.main.get().runtimeClasspath
 
             mainClass.set(className)
@@ -372,7 +373,10 @@ tasks {
 
     registerTask("runImageJMain", "sc.iview.ImageJMain", "scenery.")
 
-    registerTask("runInstancingBenchmark", "sc.iview.commands.demo.advanced.InstancingBenchmark", "sciview.benchmark.")
+    registerTask("runInstancingBenchmark",
+        "sc.iview.commands.demo.advanced.InstancingBenchmark",
+        "sciview.benchmark.",
+        "demos.advanced")
 
 
     sourceSets.main.get().allSource.files

--- a/src/main/kotlin/sc/iview/commands/MenuWeights.kt
+++ b/src/main/kotlin/sc/iview/commands/MenuWeights.kt
@@ -119,6 +119,7 @@ object MenuWeights {
     const val DEMO_ADVANCED_FLYBRAIN = 1.5
     const val DEMO_ADVANCED_BDVSLICING = 2.0
     const val DEMO_ADVANCED_MESHTEXTURE = 3.0
+    const val DEMO_ADVANCED_INSTANCE_BENCHMARK = 4.0
     // Help
     const val HELP_HELP = 0.0
     const val HELP_ABOUT = 200.0

--- a/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
@@ -7,6 +7,7 @@ import graphics.scenery.ShaderMaterial
 import graphics.scenery.utils.extensions.times
 import org.joml.Vector3f
 import org.joml.Vector4f
+import org.scijava.ItemVisibility
 import org.scijava.command.Command
 import org.scijava.command.CommandService
 import org.scijava.log.LogService
@@ -46,6 +47,16 @@ class InstancingBenchmark : Command {
 
     @Parameter(label = "Number of instances", min = "1", max = "100000000", stepSize = "1")
     private var numAgents = 1000
+
+    @Parameter(visibility = ItemVisibility.MESSAGE)
+    private var message = "<html> <body>" +
+            "    <div> The following execution times can be expected for each</div>" +
+            "    <div> run type for 1000 instances: </div>" +
+            "    <div> - addNode publish all:  ~ 20 seconds </div>" +
+            "    <div> - addNode publish once: ~ 1 second </div>" +
+            "    <div> - instance sequential:  ~ 0.1 seconds </div>" +
+            "    <div> - instance parallel:    &lt; 0.1 seconds </div>" +
+            "</body> </html>"
 
     @Parameter(choices = ["addNode publish all", "addNode publish once", "instanced sequential", "instanced parallel"], label = "Type of benchmark")
     private var benchmarkType = "addNode publish all"

--- a/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
@@ -20,6 +20,7 @@ import sc.iview.commands.MenuWeights
 import sc.iview.commands.demo.animation.ParticleDemo
 import java.util.*
 import kotlin.streams.asStream
+import kotlin.time.TimeSource
 
 /**
  * A benchmark that compares the conventional node publishing method with instanced geometry.
@@ -70,24 +71,27 @@ class InstancingBenchmark : Command {
     private var maxZ = 10f
 
 
+    /** Executes the benchmark with parameters stored in [numParticles] and [benchmarkType].
+     * The elapsed time is tracked and logged to the console. */
     override fun run() {
 
         var ranSuccessfully = true;
         log.info("Running instancing benchmark with $numParticles agents and type \"$benchmarkType\".")
-        val startTime = System.currentTimeMillis()
+        val timeSource = TimeSource.Monotonic
+        val start = timeSource.markNow()
         when (benchmarkType) {
-            "publishAll" -> {runAddNodePublishAll()}
-            "publishOnce" -> {runAddNodePublishOnce()}
-            "instanceSequential" -> {runInstancedSequential()}
-            "instanceParallel" -> {runInstancedParallel()}
+            "publishAll" -> runAddNodePublishAll()
+            "publishOnce" -> runAddNodePublishOnce()
+            "instanceSequential" -> runInstancedSequential()
+            "instanceParallel" -> runInstancedParallel()
             else -> {
                 log.info("Could not find benchmark type specified.\n" +
                         "Choose from: [publishAll, publishOnce, instanceSequential, instanceParallel].")
                 ranSuccessfully = false }
         }
-        val endTime = System.currentTimeMillis()
+        val end = timeSource.markNow()
         if (ranSuccessfully) {
-            log.info("Execution time: ${endTime - startTime} milliseconds")
+            log.info("Execution time: ${end - start}")
         }
     }
 
@@ -131,14 +135,14 @@ class InstancingBenchmark : Command {
 
     }
 
-    /** This runs the benchmark using instanced geometry with a sequential scene population loop. */
+    /** This runs the benchmark using instanced geometry with a sequential scene population loop.
+     * It creates a sphere with 5cm radius and 10cm height as our parent.
+     * It's important to use the custom shaders provided by this class in the material,
+     * as the default instanced material does not include color as property. The actual
+     * shader types do not need to be given, as Vertex Shader and Fragment Shader are the
+     * default shader types scenery is looking for.*/
     private fun runInstancedSequential() {
 
-        // This creates a sphere with 5cm radius and 10cm height as our parent.
-        // It's important to use the custom shaders provided by this class in the material,
-        // as the default instanced material does not include color as property. The actual
-        // shader types do not need to be given, as Vertex Shader and Fragment Shader are the
-        // default shader types scenery is looking for.
         val parent = Icosphere(0.1f, 2)
         parent.setMaterial(ShaderMaterial.fromClass(ParticleDemo::class.java))
         parent.ifMaterial {

--- a/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
@@ -1,0 +1,192 @@
+package sc.iview.commands.demo.advanced
+
+import graphics.scenery.Group
+import graphics.scenery.Icosphere
+import graphics.scenery.InstancedNode
+import graphics.scenery.ShaderMaterial
+import graphics.scenery.utils.extensions.times
+import org.joml.Vector3f
+import org.joml.Vector4f
+import org.scijava.command.Command
+import org.scijava.command.CommandService
+import org.scijava.log.LogService
+import org.scijava.plugin.Menu
+import org.scijava.plugin.Parameter
+import org.scijava.plugin.Plugin
+import sc.iview.SciView
+import sc.iview.SciView.Companion.create
+import sc.iview.commands.MenuWeights
+import sc.iview.commands.demo.animation.ParticleDemo
+import java.util.*
+import kotlin.streams.asStream
+
+@Plugin(
+    type = Command::class,
+    label = "Instancing Benchmark",
+    menuRoot = "SciView",
+    menu = [Menu(label = "Demo", weight = MenuWeights.DEMO), Menu(
+        label = "Advanced",
+        weight = MenuWeights.DEMO_ADVANCED
+    ), Menu(label = "Instance Benchmark", weight = MenuWeights.DEMO_ADVANCED_INSTANCE_BENCHMARK)]
+)
+class InstancingBenchmark : Command {
+    @Parameter
+    private lateinit var log: LogService
+
+    @Parameter
+    private lateinit var sciview: SciView
+
+    @Parameter(label = "Number of instances", min = "1", max = "100000000", stepSize = "1")
+    private var numAgents = 1000
+
+    @Parameter(choices = ["addNode publish all", "addNode publish once", "instanced sequential", "instanced parallel"], label = "Type of benchmark")
+    private var benchmarkType = "addNode publish all"
+
+    val rng = Random(17)
+    @Parameter(label = "X range", min = "0.1", max = "1000", style = "format:0.0", stepSize = "0.1")
+    private var maxX = 10f
+    @Parameter(label = "Y range", min = "0.1", max = "1000", style = "format:0.0", stepSize = "0.1")
+    private var maxY = 10f
+    @Parameter(label = "Z range", min = "0.1", max = "1000", style = "format:0.0", stepSize = "0.1")
+    private var maxZ = 10f
+
+
+    override fun run() {
+
+        log.info("Running instancing benchmark with $numAgents agents and type \"$benchmarkType\".")
+        val startTime = System.currentTimeMillis()
+        when (benchmarkType) {
+            "addNode publish all" -> {runAddNodePublishAll()}
+            "addNode publish once" -> {runAddNodePublishOnce()}
+            "instanced sequential" -> {runInstancedSequential()}
+            "instanced parallel" -> {runInstancedParallel()}
+        }
+        val endTime = System.currentTimeMillis()
+        log.info("Execution time: ${endTime - startTime} milliseconds")
+    }
+
+    /** This runs the benchmark using [SciView.addNode] with `activePublish = true`.*/
+    private fun runAddNodePublishAll() {
+
+        val parent = Group()
+        sciview.addNode(parent)
+        for (i in 0 until numAgents) {
+            val n = Icosphere(0.1f, 2)
+            n.name = "agent_$i"
+            val x = rng.nextFloat() * maxX - maxX/2
+            val y = rng.nextFloat() * maxY - maxY/2
+            val z = rng.nextFloat() * maxZ - maxZ/2
+            n.material {
+                diffuse = Vector3f(rng.nextFloat(), rng.nextFloat(), i.toFloat() / numAgents.toFloat())
+            }
+            n.spatial().position = Vector3f(x, y, z)
+            sciview.addNode(n, activePublish = true, parent = parent)
+        }
+    }
+
+    /** This runs the benchmark using [SciView.addNode] with `activePublish = false` and a single
+     * scene update at the end.*/
+    private fun runAddNodePublishOnce() {
+
+        val parent = Group()
+        sciview.addNode(parent)
+        for (i in 0 until numAgents) {
+            val n = Icosphere(0.1f, 2)
+            n.name = "agent_$i"
+            val x = rng.nextFloat() * maxX - maxX/2
+            val y = rng.nextFloat() * maxY - maxY/2
+            val z = rng.nextFloat() * maxZ - maxZ/2
+            n.material {
+                diffuse = Vector3f(rng.nextFloat(), rng.nextFloat(), i.toFloat() / numAgents.toFloat())
+            }
+            n.spatial().position = Vector3f(x, y, z)
+            sciview.addNode(n, activePublish = false, parent = parent)
+        }
+        sciview.addNode(parent, activePublish = true)
+
+    }
+
+    /** This runs the benchmark using instanced geometry with a sequential scene population loop. */
+    private fun runInstancedSequential() {
+
+        // This creates a sphere with 5cm radius and 10cm height as our parent.
+        // It's important to use the custom shaders provided by this class in the material,
+        // as the default instanced material does not include color as property. The actual
+        // shader types do not need to be given, as Vertex Shader and Fragment Shader are the
+        // default shader types scenery is looking for.
+        val parent = Icosphere(0.1f, 2)
+        parent.setMaterial(ShaderMaterial.fromClass(ParticleDemo::class.java))
+        parent.ifMaterial {
+            ambient = Vector3f(0.1f, 0f, 0f)
+            diffuse = Vector3f(0.8f, 0.7f, 0.7f)
+            diffuse = Vector3f(0.05f, 0f, 0f)
+            metallic = 0.01f
+            roughness = 0.5f
+        }
+        parent.name = "Agent_Parent"
+
+        // This now creates the template InstancedNode from the cone we've made.
+        val sphere = InstancedNode(parent)
+        // Here, we add the color as additional instanced property. Instanced properties
+        // should be aligned to 4*32bit boundaries, hence the use of Vector4f instead of Vector3f here.
+        sphere.instancedProperties["Color"] = { Vector4f(1.0f) }
+        sciview.addNode(sphere)
+
+        (0 until numAgents).forEach {
+            val n = sphere.addInstance()
+            n.name = "agent_$it"
+            // This sets up the initial positions of the agents
+            val x = rng.nextFloat() * maxX - maxX/2
+            val y = rng.nextFloat() * maxY - maxY/2
+            val z = rng.nextFloat() * maxZ - maxZ/2
+            val col = Vector4f(rng.nextFloat(), rng.nextFloat(), it.toFloat() / numAgents.toFloat(), 1.0f)
+            n.instancedProperties["Color"] = { col }
+            n.spatial().position = Vector3f(x, y, z)
+        }
+
+    }
+
+    /** This runs the benchmark using instanced geometry with a parallel scene population loop. */
+    private fun runInstancedParallel() {
+
+        val sphere = Icosphere(0.1f, 2)
+        sphere.setMaterial(ShaderMaterial.fromClass(ParticleDemo::class.java))
+        sphere.ifMaterial {
+            ambient = Vector3f(0.1f, 0f, 0f)
+            diffuse = Vector3f(0.8f, 0.7f, 0.7f)
+            diffuse = Vector3f(0.05f, 0f, 0f)
+            metallic = 0.01f
+            roughness = 0.5f
+        }
+        sphere.name = "Agent_Parent"
+
+        val parent = InstancedNode(sphere)
+        parent.instancedProperties["Color"] = { Vector4f(1.0f) }
+        sciview.addNode(parent)
+
+        (0 until numAgents).asSequence().asStream().parallel().forEach {
+            val n = parent.addInstance()
+            n.name = "agent_$it"
+
+            val x = rng.nextFloat() * maxX - maxX/2
+            val y = rng.nextFloat() * maxY - maxY/2
+            val z = rng.nextFloat() * maxZ - maxZ/2
+            val vel = Vector3f(rng.nextFloat(), rng.nextFloat(), rng.nextFloat()) * 0.5f
+            val col = Vector4f(rng.nextFloat(), rng.nextFloat(), it.toFloat() / numAgents.toFloat(), 1.0f)
+            n.instancedProperties["Color"] = { col }
+            n.spatial().position = Vector3f(x, y, z)
+        }
+    }
+
+    companion object {
+        @Throws(Exception::class)
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val sv = create()
+            val command = sv.scijavaContext!!.getService(CommandService::class.java)
+            val argmap = HashMap<String, Any>()
+            command.run(ParticleDemo::class.java, true, argmap)
+        }
+    }
+
+}

--- a/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
+++ b/src/main/kotlin/sc/iview/commands/demo/advanced/InstancingBenchmark.kt
@@ -20,6 +20,14 @@ import sc.iview.commands.demo.animation.ParticleDemo
 import java.util.*
 import kotlin.streams.asStream
 
+/**
+ * A benchmark that compares the conventional node publishing method with instanced geometry.
+ * Nodes can either be published separately or cumulatively at the end.
+ * Creating the instanced geometry can be run sequentially or in parallel (using a stream over an array).
+ *
+ * @author Samuel Pantze
+ */
+
 @Plugin(
     type = Command::class,
     label = "Instancing Benchmark",


### PR DESCRIPTION
This PR adds a benchmark to the `Demo > Advanced` menu.
It allows you to compare the conventional means of node publishing with instanced geometry, using spheres as objects.
The benchmark type can be run in four ways:
- publish each node separately
- publish all nodes cumulatively at the end
- populate the scene with instanced geometry sequentially
- populate the scene with instanced geometry using a parallel stream over the array, which is even faster

There are also parameters for the number of (instanced) particles (defaults to `1000`) and the spread in each dimension.