### PR TITLE
Fix: recursive delete calls no longer use activePublish

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1189,7 +1189,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
             }
         }
         if (runRecursive) {
-            activeNode?.runRecursive( { node: Node -> this.deleteNode(node) })
+            activeNode?.runRecursive { node: Node -> this.deleteNode(node, activePublish = false) }
         } else {
             deleteNode(activeNode)
         }
@@ -1216,7 +1216,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         }
 
         for (child in node!!.children) {
-            deleteNode(child, activePublish)
+            // child node deletions should not be published actively
+            deleteNode(child, false)
         }
         objectService.removeObject(node)
         node.parent?.removeChild(node)


### PR DESCRIPTION
This should fix the slow deletion process for large groups of objects. Previously every child node deletion and every recursive call used `activePublish = true`, which slowed down sciview by a lot.