### PR TITLE
fix: removed nodeType dependency on scenery

### DIFF
--- a/src/main/java/sc/iview/commands/file/ExportN5.java
+++ b/src/main/java/sc/iview/commands/file/ExportN5.java
@@ -91,7 +91,7 @@ public class ExportN5 implements Command {
             }
 
         } else {
-            logService.warn("Node is " + sciView.getActiveNode().getNodeType() + " cannot export to N5.");
+            logService.warn("Node is " + sciView.getActiveNode().getClass() + " cannot export to N5.");
         }
     }
 

--- a/src/main/java/sc/iview/commands/file/ExportN5.java
+++ b/src/main/java/sc/iview/commands/file/ExportN5.java
@@ -91,7 +91,7 @@ public class ExportN5 implements Command {
             }
 
         } else {
-            logService.warn("Node is " + sciView.getActiveNode().getClass() + " cannot export to N5.");
+            logService.warn("Node is " + sciView.getActiveNode().getClass().getSimpleName() + " cannot export to N5.");
         }
     }
 

--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1814,7 +1814,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * Convenience function for getting a string of info about a Node
      */
     fun nodeInfoString(n: Node): String {
-        return "Node name: " + n.name + " Node type: " + n.nodeType + " To String: " + n
+        return "Node name: " + n.name + " Node type: " + n.javaClass + " To String: " + n
     }
 
     /**

--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1814,7 +1814,7 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * Convenience function for getting a string of info about a Node
      */
     fun nodeInfoString(n: Node): String {
-        return "Node name: " + n.name + " Node type: " + n.javaClass + " To String: " + n
+        return "Node name: ${n.name} Node type: ${n.javaClass.simpleName} To String: $n"
     }
 
     /**

--- a/src/main/kotlin/sc/iview/ui/ContextPopUp.kt
+++ b/src/main/kotlin/sc/iview/ui/ContextPopUp.kt
@@ -35,6 +35,6 @@ import javax.swing.JPopupMenu
 class ContextPopUp(n: Node) : JPopupMenu() {
     init {
         add(JMenuItem("Name: " + n.name))
-        add(JMenuItem("Type: " + n.javaClass))
+        add(JMenuItem("Type: ${n.javaClass.simpleName}"))
     }
 }

--- a/src/main/kotlin/sc/iview/ui/ContextPopUp.kt
+++ b/src/main/kotlin/sc/iview/ui/ContextPopUp.kt
@@ -35,6 +35,6 @@ import javax.swing.JPopupMenu
 class ContextPopUp(n: Node) : JPopupMenu() {
     init {
         add(JMenuItem("Name: " + n.name))
-        add(JMenuItem("Type: " + n.nodeType))
+        add(JMenuItem("Type: " + n.javaClass))
     }
 }


### PR DESCRIPTION
Scenery removed the `Node.nodeType` property in version 0.11.2. This PR fixes the occurrences of `nodeType` in Sciview and uses java classes instead, which is what @skalarproduktraum suggested.