### PR TITLE
SciView: fix VR toggling to change to stereo rendering

### DIFF
--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1668,6 +1668,8 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
      * Enable VR rendering
      */
     fun toggleVRRendering() {
+        var renderer = renderer ?: return
+
         vrActive = !vrActive
         val cam = scene.activeObserver as? DetachedHeadCamera ?: return
         var ti: TrackerInput? = null
@@ -1690,25 +1692,29 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         }
         if (vrActive && ti != null) {
             cam.tracker = ti
+            logger.info("tracker set")
         } else {
             cam.tracker = null
         }
-        renderer!!.pushMode = false
+        renderer.pushMode = false
+
         // we need to force reloading the renderer as the HMD might require device or instance extensions
         if (renderer is VulkanRenderer && hmdAdded) {
-            replaceRenderer((renderer as VulkanRenderer).javaClass.simpleName, true, true)
-            (renderer as VulkanRenderer).toggleVR()
-            while (!(renderer as VulkanRenderer).initialized /* || !getRenderer().getFirstImageReady()*/) {
-                logger.debug("Waiting for renderer reinitialisation")
+            replaceRenderer(renderer.javaClass.simpleName, true, true)
+
+            logger.info("renderer replaced")
+            while (renderer.initialized == false || renderer.firstImageReady == false) {
+                renderer = this.renderer!!
+                logger.info("Waiting for renderer reinitialisation (init: ${renderer.initialized} ready: ${renderer.firstImageReady}")
                 try {
                     Thread.sleep(200)
                 } catch (e: InterruptedException) {
                     e.printStackTrace()
                 }
             }
-        } else {
-            renderer!!.toggleVR()
         }
+
+        renderer.toggleVR()
     }
 
     /**

--- a/src/main/kotlin/sc/iview/SciView.kt
+++ b/src/main/kotlin/sc/iview/SciView.kt
@@ -1692,7 +1692,6 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         }
         if (vrActive && ti != null) {
             cam.tracker = ti
-            logger.info("tracker set")
         } else {
             cam.tracker = null
         }
@@ -1701,8 +1700,6 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
         // we need to force reloading the renderer as the HMD might require device or instance extensions
         if (renderer is VulkanRenderer && hmdAdded) {
             replaceRenderer(renderer.javaClass.simpleName, true, true)
-
-            logger.info("renderer replaced")
             while (renderer.initialized == false || renderer.firstImageReady == false) {
                 renderer = this.renderer!!
                 logger.info("Waiting for renderer reinitialisation (init: ${renderer.initialized} ready: ${renderer.firstImageReady}")
@@ -1712,9 +1709,9 @@ class SciView : SceneryBase, CalibratedRealInterval<CalibratedAxis> {
                     e.printStackTrace()
                 }
             }
-        }
 
-        renderer.toggleVR()
+            renderer.toggleVR()
+        }
     }
 
     /**


### PR DESCRIPTION
When toggling VR, either via the API or the "view" menu button, the tracking would successfully initialize but the stereo rendering wouldn't switch on. Only after toggling it off and on again would it work.
This fix (credit to @skalarproduktraum) now also enables stereo rendering on toggling VR.