### PR TITLE
CellTrackingBase: add "merge selected" button, reorder button menus

### DIFF
--- a/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
@@ -137,6 +137,8 @@ open class CellTrackingBase(
     var deleteGraphCallback: (() -> Unit)? = null
     /** Deletes all annotations from this timepoint. */
     var deleteTimepointCallback: (() -> Unit)? = null
+    /** Recenter and set default scaling for volume, then center camera on volume. */
+    var resetViewCallback: (() -> Unit)? = null
 
     enum class HedgehogVisibility { Hidden, PerTimePoint, Visible }
 
@@ -229,6 +231,7 @@ open class CellTrackingBase(
         inputSetup()
 
         cellTrackingActive = true
+        rebuildGeometryCallback?.invoke()
         launchUpdaterThread()
     }
 
@@ -476,8 +479,15 @@ open class CellTrackingBase(
             color = color, pressedColor = pressedColor, touchingColor = touchingColor
         )
 
+        val resetViewButton = Button(
+            "Recenter", command = {
+                resetViewCallback?.invoke()
+            }, byTouch = true, depressDelay = 250,
+            color = color, pressedColor = pressedColor, touchingColor = touchingColor
+        )
+
         val timeControlRow = Row(goToFirstBtn, playSlowerBtn, togglePlaybackDirBtn, playFasterBtn, goToLastBtn)
-        val undoRedoRow = Row(undoButton, redoButton)
+        val undoRedoRow = Row(undoButton, redoButton, resetViewButton)
         generalMenu = createWristMenuColumn(timeControlRow, undoRedoRow, name = "Left Undo Menu")
         generalMenu?.visible = false
 
@@ -1106,6 +1116,7 @@ open class CellTrackingBase(
 
         sciview.toggleVRRendering()
         logger.info("Shut down and disabled VR environment.")
+        rebuildGeometryCallback?.invoke()
     }
 
 }

--- a/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
@@ -39,7 +39,8 @@ import kotlin.concurrent.thread
  * @param [sciview] The [SciView] instance to use
  */
 open class CellTrackingBase(
-    open var sciview: SciView
+    open var sciview: SciView,
+    val resolutionScale: Float = 1f
 ) {
     val logger by lazyLogger(System.getProperty("scenery.LogLevel", "info"))
 
@@ -165,7 +166,7 @@ open class CellTrackingBase(
     private val observers = mutableListOf<TimepointObserver>()
 
     open fun run() {
-        sciview.toggleVRRendering(resolutionScale = 0.75f)
+        sciview.toggleVRRendering(resolutionScale = resolutionScale)
         hmd = sciview.hub.getWorkingHMD() as? OpenVRHMD ?: throw IllegalStateException("Could not find headset")
 
         // Try to load the correct button mapping corresponding to the controller layout

--- a/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
@@ -132,6 +132,10 @@ open class CellTrackingBase(
     var mergeOverlapsCallback: ((Int) -> Unit)? = null
     /** Merges selected spots. */
     var mergeSelectedCallback: (() -> Unit)? = null
+    /** Deletes the whole graph. */
+    var deleteGraphCallback: (() -> Unit)? = null
+    /** Deletes all annotations from this timepoint. */
+    var deleteTimepointCallback: (() -> Unit)? = null
 
     enum class HedgehogVisibility { Hidden, PerTimePoint, Visible }
 
@@ -512,7 +516,20 @@ open class CellTrackingBase(
                 mergeSelectedCallback?.invoke()
             }, byTouch = true, depressDelay = 250, color = color, pressedColor = pressedColor, touchingColor = touchingColor
         )
-        val cleanupMenu = createWristMenuColumn(mergeOverlapsButton, mergeSelectedButton)
+
+        val deleteGraphButton = Button(
+            "Delete Graph", command = {
+                deleteGraphCallback?.invoke()
+            }, byTouch = true, depressDelay = 250, color = color, pressedColor = pressedColor, touchingColor = touchingColor
+        )
+        val deleteTimepointButton = Button(
+            "Delete TP", command = {
+                deleteTimepointCallback?.invoke()
+            }, byTouch = true, depressDelay = 250, color = color, pressedColor = pressedColor, touchingColor = touchingColor
+        )
+        val mergeRow = Row(mergeOverlapsButton, mergeSelectedButton)
+        val deleteRow = Row(deleteGraphButton, deleteTimepointButton)
+        val cleanupMenu = createWristMenuColumn(mergeRow, deleteRow)
         cleanupMenu.visible = false
     }
 

--- a/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/CellTrackingBase.kt
@@ -1087,14 +1087,20 @@ open class CellTrackingBase(
     open fun stop() {
         logger.info("Objects in the scene: ${sciview.allSceneNodes.map { it.name }}")
         cellTrackingActive = false
-        lightTetrahedron.forEach { sciview.deleteNode(it) }
+        if (::lightTetrahedron.isInitialized) {
+            lightTetrahedron.forEach { sciview.deleteNode(it) }
+        }
         // Try to find and delete possibly existing VR objects
         listOf("Shell", "leftHand", "rightHand").forEach {
             val n = sciview.find(it)
             n?.let { sciview.deleteNode(n) }
         }
-        sciview.deleteNode(rightVRController?.model)
-        sciview.deleteNode(leftVRController?.model)
+        rightVRController?.model?.let {
+            sciview.deleteNode(it)
+        }
+        leftVRController?.model?.let {
+            sciview.deleteNode(it)
+        }
 
         logger.info("Cleaned up basic VR objects. Objects left: ${sciview.allSceneNodes.map { it.name }}")
 

--- a/src/main/kotlin/sc/iview/commands/analysis/EyeTracking.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/EyeTracking.kt
@@ -502,9 +502,13 @@ class EyeTracking(
         n?.let { sciview.deleteNode(it) }
         // Delete definitely existing objects
         listOf(referenceTarget, calibrationTarget, laser, debugBoard, hedgehogs).forEach {
-            sciview.deleteNode(it)
+            try {
+                sciview.deleteNode(it)
+            } catch (e: Exception) {
+                logger.warn("Failed to delete $it")
+            }
         }
-        logger.info("Successfully cleaned up eye tracking environemt.")
+        logger.info("Successfully cleaned up eye tracking environment.")
         super.stop()
     }
 

--- a/src/main/kotlin/sc/iview/commands/analysis/EyeTracking.kt
+++ b/src/main/kotlin/sc/iview/commands/analysis/EyeTracking.kt
@@ -37,8 +37,9 @@ import kotlin.time.TimeSource
  * [trackCreationCallback], which is called on every spine graph vertex that is extracted
  */
 class EyeTracking(
-    sciview: SciView
-): CellTrackingBase(sciview) {
+    sciview: SciView,
+    resolutionScale: Float = 1f,
+): CellTrackingBase(sciview, resolutionScale) {
 
     lateinit var pupilTracker: PupilEyeTracker
     val calibrationTarget = Icosphere(0.02f, 2)


### PR DESCRIPTION
This PR adds:
- a new "merge selected" button for the cell tracking interface in manvr3d. 
- reorganises the button menus in manvr3d and improves the naming of methods in the 3D cursor tool.
- adds connection checking to the EyeTracking class to allow fallback to the default VR environment
- add a reset view button
- add buttons for deletion of single timepoint or whole graph
- make the scene cleanup after stopping VR more robust